### PR TITLE
Add module for concrete workers to tag unique id to thread

### DIFF
--- a/eventq_base/lib/eventq_base.rb
+++ b/eventq_base/lib/eventq_base.rb
@@ -16,4 +16,5 @@ require_relative 'eventq_base/subscription_manager_contract'
 require_relative 'eventq_base/eventq_client_contract'
 require_relative 'eventq_base/configuration'
 require_relative 'eventq_base/serialization_providers'
+require_relative 'eventq_base/worker_id'
 

--- a/eventq_base/lib/eventq_base/worker_id.rb
+++ b/eventq_base/lib/eventq_base/worker_id.rb
@@ -1,0 +1,10 @@
+module EventQ
+  # Module to be used by concrete worker classes to tag each thread working on a message
+  # Allows to be used in custom logging to track group of log messages per queue message processing.
+  module WorkerId
+    def tag_processing_thread
+      Thread.current['worker_id'] = SecureRandom.uuid
+    end
+
+  end
+end


### PR DESCRIPTION
This module can be added to concrete workers to tag their processing thread on a queue message.  Allows ease of debugging logs (Similar to rails log tagging for requests)
