### PR TITLE
aws and rabbitmq will tag processing thread to support custom logging

### DIFF
--- a/eventq_aws/eventq_aws.gemspec
+++ b/eventq_aws/eventq_aws.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
 
   spec.add_dependency 'aws-sdk-core'
-  spec.add_dependency 'eventq_base'
+  spec.add_dependency 'eventq_base', '~> 1.7.0'
   spec.add_dependency 'hash_kit'
 end

--- a/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
@@ -1,6 +1,7 @@
 module EventQ
   module Amazon
     class QueueWorker
+      include EventQ::WorkerId
 
       APPROXIMATE_RECEIVE_COUNT = 'ApproximateReceiveCount'.freeze
       MESSAGE = 'Message'.freeze
@@ -115,6 +116,7 @@ module EventQ
 
           #check that a message was received
           if response.messages.length > 0
+            tag_processing_thread
 
             msg = response.messages[0]
             retry_attempts = msg.attributes[APPROXIMATE_RECEIVE_COUNT].to_i - 1

--- a/eventq_rabbitmq/eventq_rabbitmq.gemspec
+++ b/eventq_rabbitmq/eventq_rabbitmq.gemspec
@@ -25,6 +25,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
 
   spec.add_dependency 'bunny'
-  spec.add_dependency 'eventq_base'
+  spec.add_dependency 'eventq_base', '~> 1.7.0'
   spec.add_dependency 'hash_kit'
 end

--- a/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -1,6 +1,7 @@
 module EventQ
   module RabbitMq
     class QueueWorker
+      include EventQ::WorkerId
 
       attr_accessor :is_running
 
@@ -134,6 +135,7 @@ module EventQ
 
           #check that message was received
           if payload != nil
+            tag_processing_thread
 
             message = deserialize_message(payload)
 


### PR DESCRIPTION
By default the built in logging will not show the unique id's.  The intent is for custom loggers to pull that information as necessary via setting the logger of the eventq system.
