### PR TITLE
Optional enhancement to allow usage of singleton queue client or instance per thread.

### DIFF
--- a/eventq_aws/lib/eventq_aws/aws_queue_manager.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_manager.rb
@@ -8,7 +8,7 @@ module EventQ
       def initialize(options)
 
         if options[:client] == nil
-          raise ':client (QueueClient) must be specified.'.freeze
+          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:mq_endpoint].")
         end
 
         @client = options[:client]

--- a/eventq_aws/lib/eventq_aws/aws_queue_manager.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_manager.rb
@@ -7,9 +7,7 @@ module EventQ
 
       def initialize(options)
 
-        if options[:client] == nil
-          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:aws_account_no], aws_region: options[:aws_region].")
-        end
+        raise "[#{self.class}] - :options[:client] or (options[:aws_account_no] and options[:aws_region) must be specified." unless valid_client?(options)
 
         @client = options[:client]
 
@@ -80,6 +78,12 @@ module EventQ
                                               }
                                           })
         return url
+      end
+
+      private
+
+      def valid_client?(options)
+        options[:client] || (options[:aws_account_no] && options[:aws_region])
       end
 
     end

--- a/eventq_aws/lib/eventq_aws/aws_queue_manager.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_manager.rb
@@ -8,7 +8,7 @@ module EventQ
       def initialize(options)
 
         if options[:client] == nil
-          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:mq_endpoint].")
+          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:aws_account_no], aws_region: options[:aws_region].")
         end
 
         @client = options[:client]

--- a/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
@@ -33,7 +33,7 @@ module EventQ
         configure(queue, options)
 
         if options[:client] == nil
-          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:mq_endpoint].")
+          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:aws_account_no], aws_region: options[:aws_region].")
         end
 
         raise "[#{self.class}] - Worker is already running." if running?
@@ -77,6 +77,7 @@ module EventQ
         @thread_count.times do
           thr = Thread.new do
 
+            # maintain backwards compatability bu allowing the client to be passed in via the options hash
             client = options[:client] || new_client_instance(options) # singleton or non-singleton
 
             manager = EventQ::Amazon::QueueManager.new({ client: client })

--- a/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
@@ -109,7 +109,7 @@ module EventQ
 
         end
 
-        if options.key?(:wait) && options[:wait] == true
+        if options[:wait] == true
           @threads.each { |thr| thr.join }
         end
 
@@ -239,7 +239,6 @@ module EventQ
       private
 
       def new_client_instance(options)
-        raise "[#{self.class}] - AWS Account No and Region not present." unless aws_creds_present?(options)
         EventQ::Amazon::QueueClient.new({ aws_account_number: options[:aws_account_no], aws_region: options[:aws_region] })
       end
 

--- a/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
@@ -242,10 +242,6 @@ module EventQ
         EventQ::Amazon::QueueClient.new({ aws_account_number: options[:aws_account_no], aws_region: options[:aws_region] })
       end
 
-      def aws_creds_present?(options)
-        (options[:aws_account_no] && options[:aws_region])
-      end
-
       def process_message(response, client, queue, q, block)
         msg = response.messages[0]
         retry_attempts = msg.attributes[APPROXIMATE_RECEIVE_COUNT].to_i - 1

--- a/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
@@ -32,9 +32,7 @@ module EventQ
 
         configure(queue, options)
 
-        if options[:client] == nil
-          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:aws_account_no], aws_region: options[:aws_region].")
-        end
+        raise "[#{self.class}] - :options[:client] or (options[:aws_account_no] and options[:aws_region) must be specified." unless valid_client?(options)
 
         raise "[#{self.class}] - Worker is already running." if running?
 
@@ -237,6 +235,10 @@ module EventQ
       end
 
       private
+
+      def valid_client?(options)
+        options[:client] || (options[:aws_account_no] && options[:aws_region])
+      end
 
       def new_client_instance(options)
         EventQ::Amazon::QueueClient.new({ aws_account_number: options[:aws_account_no], aws_region: options[:aws_region] })

--- a/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
@@ -243,7 +243,7 @@ module EventQ
       end
 
       def aws_creds_present?(options)
-        (options[:aws_account_no] != nil && options[:aws_region] != nil)
+        (options[:aws_account_no] && options[:aws_region])
       end
 
       def process_message(response, client, queue, q, block)

--- a/eventq_aws/spec/aws_queue_worker_spec.rb
+++ b/eventq_aws/spec/aws_queue_worker_spec.rb
@@ -19,25 +19,28 @@ RSpec.describe EventQ::Amazon::QueueWorker do
   end
 
   describe 'threading' do
+    let(:queue_client) { double }
+    let(:subscriber_queue) { double }
+    let(:sqs) { double }
+    let(:list) { double }
+    let(:urls) { ['/test1', '/test2'] }
+
+    before(:each) do
+      allow(subscriber_queue).to receive(:name).and_return('test.name')
+      allow(list).to receive(:queue_urls).and_return(urls)
+      allow(sqs).to receive(:list_queues).and_return(list)
+      allow(queue_client).to receive(:sqs).and_return(sqs)
+      allow(queue_client).to receive(:get_queue_url).and_return(urls[0])
+      allow(sqs).to receive(:set_queue_attributes).and_return(true)
+      allow(sqs).to receive(:receive_message).and_return(true)
+    end
+
     context 'non singleton client' do
+      before{
+        allow(EventQ::Amazon::QueueClient).to receive(:new).with({aws_account_number: 'foo', aws_region: 'bar'}).and_return(queue_client)
+      }
+
       context 'for a single thread' do
-        let(:queue_client) { double }
-        let(:subscriber_queue) { double }
-        let(:sqs) { double }
-        let(:list) { double }
-        let(:urls) { ['/test1', '/test2'] }
-
-        before{
-          allow(EventQ::Amazon::QueueClient).to receive(:new).with({aws_account_number: 'foo', aws_region: 'bar'}).and_return(queue_client)
-          allow(subscriber_queue).to receive(:name).and_return('test.name')
-          allow(list).to receive(:queue_urls).and_return(urls)
-          allow(sqs).to receive(:list_queues).and_return(list)
-          allow(queue_client).to receive(:sqs).and_return(sqs)
-          allow(queue_client).to receive(:get_queue_url).and_return(urls[0])
-          allow(sqs).to receive(:set_queue_attributes).and_return(true)
-          allow(sqs).to receive(:receive_message).and_return(true)
-        }
-
         it 'will create an instance' do
           expect(EventQ::Amazon::QueueClient).to receive(:new).with({aws_account_number: 'foo', aws_region: 'bar'}).once
           subject.start(subscriber_queue, {:sleep => 1, :thread_count => 1, aws_account_no: 'foo', aws_region: 'bar'}) do |event, args|
@@ -50,23 +53,6 @@ RSpec.describe EventQ::Amazon::QueueWorker do
       end
 
       context 'for multiple threads' do
-        let(:queue_client) { double }
-        let(:subscriber_queue) { double }
-        let(:sqs) { double }
-        let(:list) { double }
-        let(:urls) { ['/test1', '/test2'] }
-
-        before{
-          allow(EventQ::Amazon::QueueClient).to receive(:new).with({aws_account_number: 'foo', aws_region: 'bar'}).and_return(queue_client)
-          allow(subscriber_queue).to receive(:name).and_return('test.name')
-          allow(list).to receive(:queue_urls).and_return(urls)
-          allow(sqs).to receive(:list_queues).and_return(list)
-          allow(queue_client).to receive(:sqs).and_return(sqs)
-          allow(queue_client).to receive(:get_queue_url).and_return(urls[0])
-          allow(sqs).to receive(:set_queue_attributes).and_return(true)
-          allow(sqs).to receive(:receive_message).and_return(true)
-        }
-
         it 'will create an instance' do
           expect(EventQ::Amazon::QueueClient).to receive(:new).with({aws_account_number: 'foo', aws_region: 'bar'}).thrice
           subject.start(subscriber_queue, {:sleep => 1, :thread_count => 3, aws_account_no: 'foo', aws_region: 'bar'}) do |event, args|
@@ -80,27 +66,22 @@ RSpec.describe EventQ::Amazon::QueueWorker do
     end
 
     context 'singleton client' do
-      let(:queue_client) { double }
-      let(:subscriber_queue) { double }
-      let(:sqs) { double }
-      let(:list) { double }
-      let(:urls) { ['/test1', '/test2'] }
-
-      before{
-        allow(subscriber_queue).to receive(:name).and_return('test.name')
-        allow(list).to receive(:queue_urls).and_return(urls)
-        allow(sqs).to receive(:list_queues).and_return(list)
-        allow(queue_client).to receive(:sqs).and_return(sqs)
-        allow(queue_client).to receive(:get_queue_url).and_return(urls[0])
-        allow(sqs).to receive(:set_queue_attributes).and_return(true)
-        allow(sqs).to receive(:receive_message).and_return(true)
-      }
-
       it 'will not create an instance' do
         expect(EventQ::Amazon::QueueClient).not_to receive(:new)
         subject.start(subscriber_queue, {:sleep => 1, :thread_count => 1, client: queue_client }) do |event, args|
           recieved+=1
         end
+
+        sleep(2)
+        subject.stop
+      end
+    end
+
+    context 'when client params not supplied' do
+      it 'raises an exception' do
+        expect{ subject.start(subscriber_queue, {:sleep => 1, :thread_count => 1 }) do |event, args|
+          recieved+=1
+        end }.to raise_error
 
         sleep(2)
         subject.stop

--- a/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -84,6 +84,7 @@ module EventQ
 
               #check if the worker is still allowed to run and break out of thread loop if not
               if !@is_running
+                connection.close
                 break
               end
 

--- a/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -327,7 +327,6 @@ module EventQ
       private
 
       def new_client_instance(options)
-        raise "[#{self.class}] - MQ Endpoint not present." unless options[:mq_endpoint]
         EventQ::RabbitMq::QueueClient.new({endpoint: options[:mq_endpoint] })
       end
 

--- a/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -28,7 +28,7 @@ module EventQ
         raise "[#{self.class}] - Worker is already running." if running?
 
         if options[:client] == nil
-          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:aws_account_no] && options[:aws_region].")
+          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:mq_endpoint].")
         end
 
         EventQ.log(:info, "[#{self.class}] - Listening for messages.")
@@ -76,6 +76,7 @@ module EventQ
         @thread_count.times do
           thr = Thread.new do
 
+            # maintain backwards compatability bu allowing the client to be passed in via the options hash
             client = options[:client] || new_client_instance(options) # singleton or non-singleton
             connection = client.get_connection
 
@@ -85,6 +86,7 @@ module EventQ
               #check if the worker is still allowed to run and break out of thread loop if not
               if !@is_running
                 connection.close
+                #TODO - do we need to close the channel here also?
                 break
               end
 

--- a/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -124,7 +124,7 @@ module EventQ
 
         end
 
-        if options.key?(:wait) && options[:wait] == true
+        if options[:wait] == true
           @threads.each { |thr| thr.join }
         end
 

--- a/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -27,9 +27,8 @@ module EventQ
 
         raise "[#{self.class}] - Worker is already running." if running?
 
-        if options[:client] == nil
-          EventQ.log(:info, "[#{self.class}] - options[:client] is now deprecated!!, please pass options[:mq_endpoint].")
-        end
+        raise "[#{self.class}] - :options[:client] or options[:mq_endpoint] must be specified." unless valid_client?(options)
+
 
         EventQ.log(:info, "[#{self.class}] - Listening for messages.")
 
@@ -325,6 +324,10 @@ module EventQ
       end
 
       private
+
+      def valid_client?(options)
+        options[:client] || options[:mq_endpoint]
+      end
 
       def new_client_instance(options)
         EventQ::RabbitMq::QueueClient.new({endpoint: options[:mq_endpoint] })

--- a/eventq_rabbitmq/spec/eventq_rabbitmq/rabbitmq_queue_worker_spec.rb
+++ b/eventq_rabbitmq/spec/eventq_rabbitmq/rabbitmq_queue_worker_spec.rb
@@ -1,11 +1,7 @@
 RSpec.describe EventQ::RabbitMq::QueueWorker do
 
-  let(:client) do
-    return EventQ::RabbitMq::QueueClient.new({ endpoint: 'rabbitmq' })
-  end
-
+  let(:client) { EventQ::RabbitMq::QueueClient.new({ endpoint: 'rabbitmq' }) }
   let(:connection) { client.get_connection }
-
   let(:channel) { connection.create_channel }
 
   after do
@@ -62,7 +58,7 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
       end
       let(:payload) do
         {
-            content: { text: 'ABC' }
+          content: { text: 'ABC' }
         }
       end
       let(:json) do
@@ -144,6 +140,73 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
 
       after do
         EventQ::NonceManager.reset
+      end
+    end
+  end
+
+  describe 'threading' do
+    context 'non singleton client' do
+      context 'for a single thread' do
+        let(:client) { double }
+        let(:connection) { double }
+        let(:channel) { double }
+        let(:subscriber_queue) { EventQ::Queue.new }
+        before{
+          allow(client).to receive(:get_connection).and_return(connection)
+          allow(connection).to receive(:create_channel).and_return(channel)
+          allow(channel).to receive(:close).and_return(true)
+          allow(connection).to receive(:close).and_return(true)
+        }
+        it 'will create an instance' do
+          expect(EventQ::RabbitMq::QueueClient).to receive(:new).with({ endpoint: 'rabbitmq' }).once
+          subject.start(subscriber_queue, { mq_endpoint: 'rabbitmq', wait: false, sleep: 0, thread_count: 1 }) do |content, args|
+            received_count += 1
+          end
+
+          sleep(2)
+        end
+      end
+
+      context 'for multiple threads' do
+        let(:client) { double }
+        let(:connection) { double }
+        let(:channel) { double }
+        let(:subscriber_queue) { EventQ::Queue.new }
+        before{
+          allow(client).to receive(:get_connection).and_return(connection)
+          allow(connection).to receive(:create_channel).and_return(channel)
+          allow(channel).to receive(:close).and_return(true)
+          allow(connection).to receive(:close).and_return(true)
+        }
+        it 'will create an instance' do
+          expect(EventQ::RabbitMq::QueueClient).to receive(:new).with({ endpoint: 'rabbitmq' }).thrice
+          subject.start(subscriber_queue, { mq_endpoint: 'rabbitmq', wait: false, sleep: 0, thread_count: 3 }) do |content, args|
+            received_count += 1
+          end
+
+          sleep(2)
+        end
+      end
+    end
+
+    context 'singleton client' do
+      let(:client) { double }
+      let(:connection) { double }
+      let(:channel) { double }
+      let(:subscriber_queue) { EventQ::Queue.new }
+      before{
+        allow(client).to receive(:get_connection).and_return(connection)
+        allow(connection).to receive(:create_channel).and_return(channel)
+        allow(channel).to receive(:close).and_return(true)
+        allow(connection).to receive(:close).and_return(true)
+      }
+      it 'will not create an instance' do
+        expect(EventQ::RabbitMq::QueueClient).not_to receive(:new)
+        subject.start(subscriber_queue, { client: client, wait: false, sleep: 0, thread_count: 1 }) do |content, args|
+          received_count += 1
+        end
+
+        sleep(2)
       end
     end
   end

--- a/eventq_rabbitmq/spec/eventq_rabbitmq/rabbitmq_queue_worker_spec.rb
+++ b/eventq_rabbitmq/spec/eventq_rabbitmq/rabbitmq_queue_worker_spec.rb
@@ -151,12 +151,14 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
         let(:connection) { double }
         let(:channel) { double }
         let(:subscriber_queue) { EventQ::Queue.new }
+
         before{
           allow(client).to receive(:get_connection).and_return(connection)
           allow(connection).to receive(:create_channel).and_return(channel)
           allow(channel).to receive(:close).and_return(true)
           allow(connection).to receive(:close).and_return(true)
         }
+
         it 'will create an instance' do
           expect(EventQ::RabbitMq::QueueClient).to receive(:new).with({ endpoint: 'rabbitmq' }).once
           subject.start(subscriber_queue, { mq_endpoint: 'rabbitmq', wait: false, sleep: 0, thread_count: 1 }) do |content, args|
@@ -172,12 +174,14 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
         let(:connection) { double }
         let(:channel) { double }
         let(:subscriber_queue) { EventQ::Queue.new }
+
         before{
           allow(client).to receive(:get_connection).and_return(connection)
           allow(connection).to receive(:create_channel).and_return(channel)
           allow(channel).to receive(:close).and_return(true)
           allow(connection).to receive(:close).and_return(true)
         }
+
         it 'will create an instance' do
           expect(EventQ::RabbitMq::QueueClient).to receive(:new).with({ endpoint: 'rabbitmq' }).thrice
           subject.start(subscriber_queue, { mq_endpoint: 'rabbitmq', wait: false, sleep: 0, thread_count: 3 }) do |content, args|
@@ -194,12 +198,14 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
       let(:connection) { double }
       let(:channel) { double }
       let(:subscriber_queue) { EventQ::Queue.new }
+
       before{
         allow(client).to receive(:get_connection).and_return(connection)
         allow(connection).to receive(:create_channel).and_return(channel)
         allow(channel).to receive(:close).and_return(true)
         allow(connection).to receive(:close).and_return(true)
       }
+
       it 'will not create an instance' do
         expect(EventQ::RabbitMq::QueueClient).not_to receive(:new)
         subject.start(subscriber_queue, { client: client, wait: false, sleep: 0, thread_count: 1 }) do |content, args|


### PR DESCRIPTION
Investigate issues with singleton in EventQ:

Currently events will treat the queue client as a singleton even if we specify non singleton in the dependency injection model in the consuming app. 

This code change aims to address that providing a means to remain backwards compatible passing in a singleton client or alternatively; pass in creds and create a new client for each thread.