### PR TITLE
Create events with initial delay

### DIFF
--- a/.aws.env.template
+++ b/.aws.env.template
@@ -1,0 +1,4 @@
+AWS_ACCESS_KEY_ID=your_aws_access_key_id
+AWS_SECRET_ACCESS_KEY=your_aws_secret_access_key
+AWS_REGION=eu-west-1
+AWS_ACCOUNT_NUMBER=your_aws_account_number

--- a/eventq_aws/README.md
+++ b/eventq_aws/README.md
@@ -25,6 +25,35 @@ After checking out the repo, run `bin/setup` to install dependencies. You can al
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
 
+### Preparing the Docker images
+
+The Docker environment depends on the `eventq/rabbitmq` image, which is built by running the setup script in eventq_rabbitmq:
+
+    $ cd ../eventq_rabbitmq/script
+    $ ./setup.sh
+
+Run the setup script of eventq_aws to build to environment. This will create the `eventq/aws` image.
+
+    $ cd script
+    $ ./setup.sh
+
+### Running the tests
+
+To run the full test suite, you need an AWS account. Put your credentials into the `.aws.env` file in the parent directory.
+
+    $ cp ../.aws.env.template ../.aws.env
+    $ vi ../.aws.env
+
+Run the whole test suite:
+
+    $ cd script
+    $ ./test.sh
+
+You can run the specs that don't depend on an AWS account with:
+
+    $ cd script
+    $ ./test.sh --tag ~integration
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/sage/eventq. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.

--- a/eventq_aws/spec/aws_eventq_client_spec.rb
+++ b/eventq_aws/spec/aws_eventq_client_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+
+RSpec.describe EventQ::Amazon::EventQClient do
+
+  let(:aws_account_number) { '123456789012' }
+  let(:aws_region) { 'eu-west-1' }
+  let(:event_type) { 'test_queue1_event1' }
+  let(:event) { 'Hello World' }
+
+  let(:queue_client) do
+    EventQ::Amazon::QueueClient.new(aws_account_number: aws_account_number, aws_region: aws_region)
+  end
+
+  subject { described_class.new(client: queue_client) }
+
+  describe '#raise_event' do
+    let(:response) { double('PublishResponse', message_id: message_id) }
+    let(:message_id) { '123' }
+
+    it 'publishes an SNS event' do
+      expect(queue_client.sns).to receive(:publish) do |options|
+        expect(options[:topic_arn]).to match %r{arn:aws:sns:#{aws_region}:#{aws_account_number}:#{event_type}}
+
+        message_json = JSON.parse(options[:message])
+        expect(message_json['content']).to eql event
+        expect(message_json['type']).to eql event_type
+
+        expect(options[:subject]).to eql event_type
+      end.and_return(response)
+
+      expect(subject.raise_event(event_type, event)).to eql message_id
+    end
+  end
+
+  describe '#raise_event_in_queue' do
+    let(:result) { double('SendMessageResult', message_id: message_id) }
+    let(:message_id) { '123' }
+    let(:queue_name) { 'What_happens_if_you_cut_the_queue_in_Britain' }
+    let(:queue) do
+      EventQ::Queue.new.tap do |queue|
+        queue.name = queue_name
+      end
+    end
+    let(:delay_seconds) { 23 }
+    let(:aws_sqs_client) { Aws::SQS::Client.new(stub_responses: true) }
+
+    before do
+      allow(queue_client).to receive(:sqs).and_return(aws_sqs_client)
+    end
+
+    it 'sends an event to SQS' do
+      expect(queue_client.sqs).to receive(:send_message) do |options|
+        message_json = JSON.parse(options[:message_body])
+        expect(message_json['content']).to eql event
+        expect(message_json['type']).to eql event_type
+
+        expect(options[:delay_seconds]).to eql delay_seconds
+      end.and_return(result)
+
+      expect(subject.raise_event_in_queue(event_type, event, queue, delay_seconds)).to eql message_id
+    end
+  end
+end

--- a/eventq_aws/spec/aws_queue_client_spec.rb
+++ b/eventq_aws/spec/aws_queue_client_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe EventQ::Amazon::QueueClient do
+  let(:options) { { aws_account_number: '123' } }
+
+  subject { described_class.new(options) }
+
+  describe '#sqs' do
+    specify do
+      expect(subject.sqs).to be_a Aws::SQS::Client
+    end
+  end
+
+  describe '#sns' do
+    specify do
+      expect(subject.sns).to be_a Aws::SNS::Client
+    end
+  end
+end

--- a/eventq_aws/spec/aws_queue_worker_spec.rb
+++ b/eventq_aws/spec/aws_queue_worker_spec.rb
@@ -1,0 +1,83 @@
+require 'spec_helper'
+
+RSpec.describe EventQ::Amazon::QueueWorker do
+
+  describe '#deserialize_message' do
+    context 'when serialization provider is OJ_PROVIDER' do
+      before do
+        EventQ::Configuration.serialization_provider = EventQ::SerializationProviders::OJ_PROVIDER
+      end
+
+      context 'when payload is for a known type' do
+        let(:a) do
+          A.new.tap do |a|
+            a.text = 'ABC'
+          end
+        end
+
+        let(:payload) { Oj.dump(a) }
+
+        it 'should deserialize the message into an object of the known type' do
+          message = subject.deserialize_message(payload)
+          expect(message).to be_a(A)
+          expect(message.text).to eq('ABC')
+        end
+      end
+
+      context 'when payload is for an unknown type' do
+        let(:a) do
+          A.new.tap do |a|
+            a.text = 'ABC'
+          end
+        end
+        let(:payload) do
+          string = Oj.dump(a)
+          JSON.load(string.sub('"^o":"A"', '"^o":"B"'))
+        end
+        let(:message) do
+          EventQ::QueueMessage.new.tap do |m|
+            m.content = payload
+          end
+        end
+        let(:json) do
+          Oj.dump(message)
+        end
+
+        it 'should deserialize the message into a Hash' do
+          message = subject.deserialize_message(json)
+          expect(message.content).to be_a(Hash)
+          expect(message.content[:text]).to eq('ABC')
+        end
+      end
+    end
+
+    context 'when serialization provider is JSON_PROVIDER' do
+      before do
+        EventQ::Configuration.serialization_provider = EventQ::SerializationProviders::JSON_PROVIDER
+      end
+
+      let(:payload) do
+        {
+            content: { text: 'ABC' }
+        }
+      end
+      let(:json) do
+        JSON.dump(payload)
+      end
+
+      it 'should deserialize payload' do
+        message = subject.deserialize_message(json)
+        expect(message).to be_a(EventQ::QueueMessage)
+        expect(message.content).to be_a(Hash)
+        expect(message.content[:text]).to eq('ABC')
+      end
+      after do
+        EventQ::Configuration.serialization_provider = EventQ::SerializationProviders::OJ_PROVIDER
+      end
+    end
+  end
+end
+
+class A
+  attr_accessor :text
+end

--- a/eventq_aws/spec/integration/aws_eventq_client_spec.rb
+++ b/eventq_aws/spec/integration/aws_eventq_client_spec.rb
@@ -18,18 +18,21 @@ RSpec.describe EventQ::Amazon::EventQClient, integration: true do
     EventQ::Amazon::EventQClient.new({ client: queue_client })
   end
 
+  let(:subscriber_queue) do
+    EventQ::Queue.new.tap do |sq|
+      sq.name = SecureRandom.uuid.to_s
+    end
+  end
+
+  let(:event_type) { 'test_queue1_event1' }
+  let(:message) { 'Hello World' }
+
   describe '#raise_event' do
 
     shared_examples 'any event raising' do
 
       it 'should raise an event object and be broadcast to a subscriber queue' do
-        event_type = 'test_queue1_event1'
-        subscriber_queue = EventQ::Queue.new
-        subscriber_queue.name = SecureRandom.uuid
-
         subscription_manager.subscribe(event_type, subscriber_queue)
-
-        message = 'Hello World'
 
         id = eventq_client.raise_event(event_type, message)
         puts "Message ID: #{id}"

--- a/eventq_aws/spec/integration/aws_eventq_client_spec.rb
+++ b/eventq_aws/spec/integration/aws_eventq_client_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe EventQ::Amazon::EventQClient do
+RSpec.describe EventQ::Amazon::EventQClient, integration: true do
 
   let(:queue_client) do
     EventQ::Amazon::QueueClient.new({ aws_account_number: EventQ.AWS_ACCOUNT_NUMBER, aws_region: 'eu-west-1' })

--- a/eventq_aws/spec/integration/aws_eventq_client_spec.rb
+++ b/eventq_aws/spec/integration/aws_eventq_client_spec.rb
@@ -18,103 +18,67 @@ RSpec.describe EventQ::Amazon::EventQClient, integration: true do
     EventQ::Amazon::EventQClient.new({ client: queue_client })
   end
 
-  context 'when EventQ.namespace is NOT specified' do
-    it 'should raise an event object and be broadcast to a subscriber queue' do
+  describe '#raise_event' do
 
-      event_type = 'test_queue1_event1'
-      subscriber_queue = EventQ::Queue.new
-      subscriber_queue.name = SecureRandom.uuid
+    shared_examples 'any event raising' do
 
-      subscription_manager.subscribe(event_type, subscriber_queue)
+      it 'should raise an event object and be broadcast to a subscriber queue' do
+        event_type = 'test_queue1_event1'
+        subscriber_queue = EventQ::Queue.new
+        subscriber_queue.name = SecureRandom.uuid
 
-      message = 'Hello World'
+        subscription_manager.subscribe(event_type, subscriber_queue)
 
-      id = eventq_client.raise_event(event_type, message)
-      puts "Message ID: #{id}"
+        message = 'Hello World'
 
-      #sleep for 2 seconds to allow the aws message to be sent to the topic and broadcast to subscribers
-      sleep(1)
+        id = eventq_client.raise_event(event_type, message)
+        puts "Message ID: #{id}"
 
-      q = queue_manager.get_queue(subscriber_queue)
+        #sleep for 2 seconds to allow the aws message to be sent to the topic and broadcast to subscribers
+        sleep(1)
 
-      puts '[QUEUE] waiting for message...'
+        q = queue_manager.get_queue(subscriber_queue)
 
-      #request a message from the queue
-      response = queue_client.sqs.receive_message({
-                                                      queue_url: q,
-                                                      max_number_of_messages: 1,
-                                                      wait_time_seconds: 5,
-                                                      message_attribute_names: ['ApproximateReceiveCount']
-                                                  })
+        puts '[QUEUE] waiting for message...'
 
-      expect(response.messages.length).to eq(1)
+        #request a message from the queue
+        response = queue_client.sqs.receive_message({
+                                                        queue_url: q,
+                                                        max_number_of_messages: 1,
+                                                        wait_time_seconds: 5,
+                                                        message_attribute_names: ['ApproximateReceiveCount']
+                                                    })
 
-      msg = response.messages[0]
-      msg_body = Oj.load(msg.body)
-      payload = Oj.load(msg_body["Message"])
-      puts "[QUEUE] - received message: #{payload}"
+        expect(response.messages.length).to eq(1)
 
-      #remove the message from the queue so that it does not get retried
-      queue_client.sqs.delete_message({ queue_url: q, receipt_handle: msg.receipt_handle })
+        msg = response.messages[0]
+        msg_body = Oj.load(msg.body)
+        payload = Oj.load(msg_body["Message"])
+        puts "[QUEUE] - received message: #{payload}"
 
-      expect(payload).to_not be_nil
-      expect(payload.content).to eq(message)
+        #remove the message from the queue so that it does not get retried
+        queue_client.sqs.delete_message({ queue_url: q, receipt_handle: msg.receipt_handle })
 
+        expect(payload).to_not be_nil
+        expect(payload.content).to eq(message)
+      end
+    end
+
+    context 'when EventQ.namespace is NOT specified' do
+      it_behaves_like 'any event raising'
+    end
+
+    context 'when EventQ.namespace is specified' do
+
+      before do
+        EventQ.namespace = 'test'
+      end
+
+      it_behaves_like 'any event raising'
+
+      after do
+        EventQ.namespace = nil
+      end
     end
   end
-
-  context 'when EventQ.namespace is specified' do
-
-    before do
-      EventQ.namespace = 'test'
-    end
-
-    it 'should raise an event object and be broadcast to a subscriber queue' do
-
-      event_type = 'test_queue1_event1'
-      subscriber_queue = EventQ::Queue.new
-      subscriber_queue.name = SecureRandom.uuid
-
-      subscription_manager.subscribe(event_type, subscriber_queue)
-
-      message = 'Hello World'
-
-      id = eventq_client.raise_event(event_type, message)
-      puts "Message ID: #{id}"
-
-      #sleep for 2 seconds to allow the aws message to be sent to the topic and broadcast to subscribers
-      sleep(1)
-
-      q = queue_manager.get_queue(subscriber_queue)
-
-      puts '[QUEUE] waiting for message...'
-
-      #request a message from the queue
-      response = queue_client.sqs.receive_message({
-                                                      queue_url: q,
-                                                      max_number_of_messages: 1,
-                                                      wait_time_seconds: 5,
-                                                      message_attribute_names: ['ApproximateReceiveCount']
-                                                  })
-
-      expect(response.messages.length).to eq(1)
-
-      msg = response.messages[0]
-      msg_body = Oj.load(msg.body)
-      payload = Oj.load(msg_body["Message"])
-      puts "[QUEUE] - received message: #{payload}"
-
-      #remove the message from the queue so that it does not get retried
-      queue_client.sqs.delete_message({ queue_url: q, receipt_handle: msg.receipt_handle })
-
-      expect(payload).to_not be_nil
-      expect(payload.content).to eq(message)
-
-    end
-
-    after do
-      EventQ.namespace = nil
-    end
-  end
-
 end

--- a/eventq_aws/spec/integration/aws_queue_manager_spec.rb
+++ b/eventq_aws/spec/integration/aws_queue_manager_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe EventQ::Amazon::QueueManager do
+RSpec.describe EventQ::Amazon::QueueManager, integration: true do
 
   let(:queue_client) do
     EventQ::Amazon::QueueClient.new({ aws_account_number: EventQ.AWS_ACCOUNT_NUMBER, aws_region: 'eu-west-1' })

--- a/eventq_aws/spec/integration/aws_queue_manager_spec.rb
+++ b/eventq_aws/spec/integration/aws_queue_manager_spec.rb
@@ -11,37 +11,30 @@ RSpec.describe EventQ::Amazon::QueueManager, integration: true do
   end
 
   describe '#get_queue' do
-    context 'when a queue does not exist' do
-      it 'should create the queue' do
-
-        queue = EventQ::Queue.new
+    let(:queue) do
+      EventQ::Queue.new.tap do |queue|
         queue.name = SecureRandom.uuid.gsub('-','')
         queue.allow_retry = true
         queue.max_retry_attempts = 5
         queue.retry_delay = 30
+      end
+    end
 
+    context 'when a queue does not exist' do
+      it 'should create the queue' do
         queue_url = subject.get_queue(queue)
         expect(queue_url).not_to be_nil
-
       end
     end
 
     context 'when a queue already exists' do
       it 'should update the the queue' do
-
-        queue = EventQ::Queue.new
-        queue.name = SecureRandom.uuid.gsub('-','')
-        queue.allow_retry = true
-        queue.max_retry_attempts = 5
-        queue.retry_delay = 30
-
         queue_url = subject.create_queue(queue)
         expect(queue_url).not_to be_nil
 
         update_url = subject.get_queue(queue)
 
         expect(update_url).to eq(queue_url)
-
       end
     end
   end
@@ -59,6 +52,7 @@ RSpec.describe EventQ::Amazon::QueueManager, integration: true do
         expect(subject.topic_exists?(event_type)).to be true
       end
     end
+
     context 'when a topic does NOT exists' do
       let(:event_type) { 'unknown-test-event' }
       it 'should return true' do

--- a/eventq_aws/spec/integration/aws_queue_worker_spec.rb
+++ b/eventq_aws/spec/integration/aws_queue_worker_spec.rb
@@ -258,81 +258,6 @@ RSpec.describe EventQ::Amazon::QueueWorker, integration: true do
     end
   end
 
-  describe '#deserialize_message' do
-    context 'when serialization provider is OJ_PROVIDER' do
-      before do
-        EventQ::Configuration.serialization_provider = EventQ::SerializationProviders::OJ_PROVIDER
-      end
-
-      context 'when payload is for a known type' do
-        let(:a) do
-          A.new.tap do |a|
-            a.text = 'ABC'
-          end
-        end
-
-        let(:payload) { Oj.dump(a) }
-
-        it 'should deserialize the message into an object of the known type' do
-          message = subject.deserialize_message(payload)
-          expect(message).to be_a(A)
-          expect(message.text).to eq('ABC')
-        end
-      end
-
-      context 'when payload is for an unknown type' do
-        let(:a) do
-          A.new.tap do |a|
-            a.text = 'ABC'
-          end
-        end
-        let(:payload) do
-          string = Oj.dump(a)
-          JSON.load(string.sub('"^o":"A"', '"^o":"B"'))
-        end
-        let(:message) do
-          EventQ::QueueMessage.new.tap do |m|
-            m.content = payload
-          end
-        end
-        let(:json) do
-          Oj.dump(message)
-        end
-
-        it 'should deserialize the message into a Hash' do
-          message = subject.deserialize_message(json)
-          expect(message.content).to be_a(Hash)
-          expect(message.content[:text]).to eq('ABC')
-        end
-      end
-    end
-
-    context 'when serialization provider is JSON_PROVIDER' do
-      before do
-        EventQ::Configuration.serialization_provider = EventQ::SerializationProviders::JSON_PROVIDER
-      end
-
-      let(:payload) do
-        {
-            content: { text: 'ABC' }
-        }
-      end
-      let(:json) do
-        JSON.dump(payload)
-      end
-
-      it 'should deserialize payload' do
-        message = subject.deserialize_message(json)
-        expect(message).to be_a(EventQ::QueueMessage)
-        expect(message.content).to be_a(Hash)
-        expect(message.content[:text]).to eq('ABC')
-      end
-      after do
-        EventQ::Configuration.serialization_provider = EventQ::SerializationProviders::OJ_PROVIDER
-      end
-    end
-  end
-
   context 'NonceManager' do
     context 'when a message has already been processed' do
       before do
@@ -370,9 +295,4 @@ RSpec.describe EventQ::Amazon::QueueWorker, integration: true do
       end
     end
   end
-
-end
-
-class A
-  attr_accessor :text
 end

--- a/eventq_aws/spec/integration/aws_queue_worker_spec.rb
+++ b/eventq_aws/spec/integration/aws_queue_worker_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe EventQ::Amazon::QueueWorker do
+RSpec.describe EventQ::Amazon::QueueWorker, integration: true do
 
   let(:queue_client) do
     EventQ::Amazon::QueueClient.new({ aws_account_number: EventQ.AWS_ACCOUNT_NUMBER, aws_region: 'eu-west-1' })

--- a/eventq_aws/spec/integration/aws_status_checker_spec.rb
+++ b/eventq_aws/spec/integration/aws_status_checker_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe EventQ::Amazon::StatusChecker, integration: true do
         e.name = SecureRandom.uuid
       end
     end
+
     context 'when a queue can be connected to' do
       before do
         queue_manager.create_queue(queue)
@@ -28,6 +29,7 @@ RSpec.describe EventQ::Amazon::StatusChecker, integration: true do
         expect(subject.queue?(queue)).to be true
       end
     end
+
     context 'when a queue cant be connected to' do
       it 'should return false' do
         expect(subject.queue?(queue)).to be false
@@ -45,6 +47,7 @@ RSpec.describe EventQ::Amazon::StatusChecker, integration: true do
         expect(subject.event_type?(event_type)).to be true
       end
     end
+
     context 'when an event_type can NOT be connected to' do
       it 'should return false' do
         expect(subject.event_type?(event_type)).to be false

--- a/eventq_aws/spec/integration/aws_status_checker_spec.rb
+++ b/eventq_aws/spec/integration/aws_status_checker_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe EventQ::Amazon::StatusChecker do
+RSpec.describe EventQ::Amazon::StatusChecker, integration: true do
 
   let(:queue_client) do
     EventQ::Amazon::QueueClient.new({ aws_account_number: EventQ.AWS_ACCOUNT_NUMBER, aws_region: 'eu-west-1' })


### PR DESCRIPTION
Together with @tosch, we came up with this draft:

We decided to implement `EventQClient#raise_event_in_queue` over `QueueClient#raise_event`, because the EventQClient class is more like the public interface of the library and the QueueClient class more private.

TODO: this currently includes the commits from https://github.com/Sage/eventq/pull/18. I will update this PR once the other PR is merged.