### PR TITLE
API-1973: Wrap message body when raising event directly in SQS

### DIFF
--- a/eventq_aws/eventq_aws.gemspec
+++ b/eventq_aws/eventq_aws.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
 
-  spec.add_dependency 'aws-sdk-core'
+  spec.add_dependency 'aws-sdk-core', '~> 2.0'
   spec.add_dependency 'eventq_base', '~> 1.15'
 
   if RUBY_PLATFORM =~ /java/

--- a/eventq_aws/lib/eventq_aws/aws_eventq_client.rb
+++ b/eventq_aws/lib/eventq_aws/aws_eventq_client.rb
@@ -63,7 +63,7 @@ module EventQ
 
           response = @client.sqs.send_message(
             queue_url: queue_url,
-            message_body: message,
+            message_body: sqs_message_body_for(message),
             delay_seconds: delay
           )
 
@@ -110,6 +110,10 @@ module EventQ
 
       def topic_arn(event_type)
         @client.get_topic_arn(event_type)
+      end
+
+      def sqs_message_body_for(payload_message)
+        JSON.dump(EventQ::Amazon::QueueWorker::MESSAGE => payload_message)
       end
     end
   end

--- a/eventq_aws/lib/eventq_aws/version.rb
+++ b/eventq_aws/lib/eventq_aws/version.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module EventQ
   module Amazon
-    VERSION = "1.14.0"
+    VERSION = "1.14.1"
   end
 end

--- a/eventq_aws/spec/aws_eventq_client_spec.rb
+++ b/eventq_aws/spec/aws_eventq_client_spec.rb
@@ -58,9 +58,11 @@ RSpec.describe EventQ::Amazon::EventQClient do
 
     it 'sends an event to SQS' do
       expect(queue_client.sqs).to receive(:send_message) do |options|
-        message_json = JSON.parse(options[:message_body])
-        expect(message_json['content']).to eql event
-        expect(message_json['type']).to eql event_type
+        outer_message_json = JSON.parse(options[:message_body])
+
+        inner_message_json = JSON.parse(outer_message_json[EventQ::Amazon::QueueWorker::MESSAGE])
+        expect(inner_message_json['content']).to eql event
+        expect(inner_message_json['type']).to eql event_type
 
         expect(options[:delay_seconds]).to eql delay_seconds
       end.and_return(result)

--- a/eventq_aws/spec/integration/aws_eventq_client_spec.rb
+++ b/eventq_aws/spec/integration/aws_eventq_client_spec.rb
@@ -170,7 +170,7 @@ RSpec.describe EventQ::Amazon::EventQClient, integration: true do
       expect(response.messages.length).to eq(1)
 
       msg = response.messages[0]
-      payload_hash = JSON.load(msg.body)
+      payload_hash = JSON.load(JSON.load(msg.body)[EventQ::Amazon::QueueWorker::MESSAGE])
       payload = class_kit.from_hash(hash: payload_hash, klass: EventQ::QueueMessage)
 
       EventQ.logger.debug {  "[QUEUE] - received message: #{msg_body}" }


### PR DESCRIPTION
When using `raise_event` to push the message to SNS, the original
message gets wrap when pushing the message to SQS.
`raise_event_in_queue` needs to wrap the message itself.

This also locks the version of aws-sdk-core to ~> 2.0, as version eventq
is not compatible to v3 of the AWS SDK yet.