### PR TITLE
Rabbitmq event args.type update

### DIFF
--- a/eventq_rabbitmq/Gemfile
+++ b/eventq_rabbitmq/Gemfile
@@ -7,7 +7,7 @@ gem 'json', '1.8.3'
 gem 'redlock'
 
 platforms :ruby do
-  gem 'openssl'
+  gem 'openssl', '2.0.4'
   gem 'oj', '2.15.0'
   gem 'pry'
 end

--- a/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_eventq_client.rb
+++ b/eventq_rabbitmq/lib/eventq_rabbitmq/rabbitmq_eventq_client.rb
@@ -45,12 +45,12 @@ module EventQ
         with_connection do |channel|
           exchange = @queue_manager.get_exchange(channel, @event_raised_exchange)
 
-          message = serialized_message(_event_type, event, context)
+          message = serialized_message(event_type, event, context)
 
           exchange.publish(message, routing_key: _event_type)
 
           EventQ.logger.debug do
-            "[#{self.class}] - Raised event to Exchange: #{_event_type} | Message: #{message}."
+            "[#{self.class}] - Raised event to Exchange. Routing Key: #{_event_type} | Message: #{message}."
           end
         end
       end
@@ -73,12 +73,12 @@ module EventQ
           q = channel.queue(_queue_name, durable: @queue_manager.durable)
           q.bind(exchange, routing_key: _event_type)
 
-          message = serialized_message(_event_type, event, context)
+          message = serialized_message(event_type, event, context)
 
           delay_exchange.publish(message, routing_key: _event_type)
 
           EventQ.logger.debug do
-            "[#{self.class}] - Raised event to Exchange: #{_event_type} | Message: #{message} | Delay: #{delay}."
+            "[#{self.class}] - Raised event to Queue: #{_queue_name} | Message: #{message} | Delay: #{delay}."
           end
         end
       end

--- a/eventq_rabbitmq/lib/eventq_rabbitmq/version.rb
+++ b/eventq_rabbitmq/lib/eventq_rabbitmq/version.rb
@@ -1,3 +1,3 @@
 module EventqRabbitmq
-  VERSION = "1.17.0"
+  VERSION = "1.17.1"
 end


### PR DESCRIPTION
Removed namespace from rabbitmq event message `args.type`.