### PR TITLE
S1T-1129 Ensure aborted messages are removed from queue

### DIFF
--- a/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_worker.rb
@@ -293,7 +293,7 @@ module EventQ
 
       def reject_message(queue, client, msg, q, retry_attempts, message, abort)
 
-        if !queue.allow_retry || retry_attempts >= queue.max_retry_attempts
+        if abort || !queue.allow_retry || retry_attempts >= queue.max_retry_attempts
 
           EventQ.logger.info("[#{self.class}] - Message rejected removing from queue. Message: #{serialize_message(message)}")
 

--- a/eventq_aws/lib/eventq_aws/aws_queue_worker_v2.rb
+++ b/eventq_aws/lib/eventq_aws/aws_queue_worker_v2.rb
@@ -233,7 +233,7 @@ module EventQ
       end
 
       def reject_message(queue, poller, msg, retry_attempts, message, abort)
-        if !queue.allow_retry || retry_attempts >= queue.max_retry_attempts
+        if abort || !queue.allow_retry || retry_attempts >= queue.max_retry_attempts
           EventQ.logger.info("[#{self.class}] - Message rejected removing from queue. Message: #{serialize_message(message)}")
 
           # remove the message from the queue so that it does not get retried again


### PR DESCRIPTION
When a message is aborted the message should not be retried.
This commit ensures that the message is removed from the queue.