### PR TITLE
Adds DLQ to eventq_aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,25 +32,29 @@ A subscription queue should be defined to receive any events raised for the subs
 
 **Attributes**
 
- - **name** [String] [Required] This is the name of the queue, it must be unique.
  - **allow_retry** [Bool] [Optional] [Default=false] This determines if the queue should allow processing failures to be retried.
- - **retry_delay** [Int] [Optional] [Default=30000] This is used to specify the time delay in milliseconds before a failed message is re-added to the subscription queue. 
- - **max_retry_attempts** [Int] [Optional] [Default=5] This is used to specify the max number of times an event should be allowed to retry before failing.
  - **allow_retry_backoff** [Bool] [Optional] [Default=false] This is used to specify if failed messages that retry should incrementally backoff. 
+ - **dlq** [EventQ::Queue] [Optional] [Default=nil] A queue that will receive the messages which were not successfully processed after maximum number of receives by consumers. This is created at the same time as the parent queue.
+ - **max_retry_attempts** [Int] [Optional] [Default=5] This is used to specify the max number of times an event should be allowed to retry before failing.
+ - **max_receive_count** [Int] [Optional] [Default=30] The maximum number of times that a message can be received by consumers. When this value is exceeded for a message the message will be automatically sent to the Dead Letter Queue.
  - **max_retry_delay** [Int] [Optional] This is used to specify the max retry delay that should apply when allowing incremental back off.
+ - **name** [String] [Required] This is the name of the queue, it must be unique.
  - **require_signature** [Bool] [Optional] [Default=false] This is used to specify if messages within this queue must be signed.
+ - **retry_delay** [Int] [Optional] [Default=30000] This is used to specify the time delay in milliseconds before a failed message is re-added to the subscription queue. 
 
 **Example**
 
-    #create a queue that allows retries and accepts a maximum of 3 retries with a 20 second delay between retries.
-    class DataChangeAddressQueue < Queue
-	    def initialize
-		    @name = 'Data.Change.Address'
-		    @allow_retry = true
-		    @retry_delay = 20000
-		    @max_retry_attempts = 3
-		end
-	end
+```ruby
+# Create a queue that allows retries and accepts a maximum of 3 retries with a 20 second delay between retries.
+class DataChangeAddressQueue < Queue
+  def initialize
+    @name = 'Data.Change.Address'
+    @allow_retry = true
+    @retry_delay = 20000
+    @max_retry_attempts = 3
+  end
+end
+```
 
 ### SubscriptionManager
 

--- a/eventq_aws/eventq_aws.gemspec
+++ b/eventq_aws/eventq_aws.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'aws-sdk-core', '~> 2.0'
   spec.add_dependency 'aws-sdk', '~> 2.0'
-  spec.add_dependency 'eventq_base', '~> 1.17'
+  spec.add_dependency 'eventq_base', '~> 1.18'
 
   if RUBY_PLATFORM =~ /java/
     spec.platform = 'java'

--- a/eventq_aws/lib/eventq_aws/version.rb
+++ b/eventq_aws/lib/eventq_aws/version.rb
@@ -2,6 +2,6 @@
 
 module EventQ
   module Amazon
-    VERSION = "1.17.0"
+    VERSION = "1.18.0"
   end
 end

--- a/eventq_base/lib/eventq_base/queue.rb
+++ b/eventq_base/lib/eventq_base/queue.rb
@@ -1,23 +1,27 @@
 module EventQ
   class Queue
-    attr_accessor :name
     attr_accessor :allow_retry
-    attr_accessor :retry_delay
-    attr_accessor :max_retry_attempts
     attr_accessor :allow_retry_back_off
+    attr_accessor :dlq
+    attr_accessor :max_retry_attempts
     attr_accessor :max_retry_delay
+    attr_accessor :name
+    attr_accessor :max_receive_count
     attr_accessor :require_signature
+    attr_accessor :retry_delay
 
     def initialize
       @allow_retry = false
-      #default retry delay is 30 seconds
-      @retry_delay = 30000
-      #default max retry attempts is 5
-      @max_retry_attempts = 5
-      #default retry back off settings
+      # Default retry back off settings
       @allow_retry_back_off = false
-      #default require signature to false
+      # Default max receive count is 30
+      @max_receive_count = 30
+      # Default max retry attempts is 5
+      @max_retry_attempts = 5
+      # Default require signature to false
       @require_signature = false
+      # Default retry delay is 30 seconds
+      @retry_delay = 30000
     end
   end
 end

--- a/eventq_base/lib/eventq_base/version.rb
+++ b/eventq_base/lib/eventq_base/version.rb
@@ -1,3 +1,3 @@
 module EventqBase
-  VERSION = "1.17.2"
+  VERSION = "1.18.0"
 end


### PR DESCRIPTION
Adds two optional attributes to a queue
 - dlq - Another `EventQ:Queue` entity which is set up as Dead Letter
 Queue in the redrive policy.
 - max_receive_count - Applied to the redrive policy to control how many
 times a message is received before being sent to the dead letter queue. This defaults to 30.

See https://aws.amazon.com/blogs/aws/amazon-sqs-new-dead-letter-queue/
for more info.

`eventq_rabbitmq` already has this functionality.