### PR TITLE
Simplify PID tracker & OJ bug fix

### DIFF
--- a/eventq.gemspec
+++ b/eventq.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'redlock'
   spec.add_dependency 'openssl'
   spec.add_dependency 'concurrent-ruby'
+  spec.add_dependency 'activesupport', '~> 4'
 
   if RUBY_PLATFORM =~ /java/
     spec.platform = 'java'

--- a/lib/eventq/eventq_base/serialization_providers/oj_serialization_provider.rb
+++ b/lib/eventq/eventq_base/serialization_providers/oj_serialization_provider.rb
@@ -14,8 +14,7 @@ module EventQ
       def deserialize(json)
         begin
           Oj.load(json)
-        rescue Oj::ParseError
-        rescue ArgumentError
+        rescue Oj::ParseError, ArgumentError
           EventQ.log(:debug, "[#{self.class}] - Failed to deserialize using Oj, falling back to JsonSerializationProvider.")
           @json_serializer.deserialize(json)
         end

--- a/lib/eventq/queue_worker.rb
+++ b/lib/eventq/queue_worker.rb
@@ -112,7 +112,13 @@ module EventQ
       EventQ.logger.info("[#{self.class}] - Stopping.")
       @is_running = false
       # Need to notify all processes(forks) to stop as well.
-      worker_status.processes.each { |process| Process.kill('TERM', process.pid) if Process.pid != process.pid }
+      worker_status.processes.each do |process|
+        begin
+          Process.kill('TERM', process.pid) if Process.pid != process.pid
+        rescue Errno::ESRCH
+          # Continue on stopping if the process already died and can't be found.
+        end
+      end
     end
 
     def running?

--- a/lib/eventq/worker_status.rb
+++ b/lib/eventq/worker_status.rb
@@ -3,12 +3,24 @@
 require 'concurrent'
 
 module EventQ
+  # Class used to represent the main worker status and the collection of forked worker processes.
+  # The main worker process will not have access to a forks collection of processes and threads.
+  # This is due to forks getting a copy of the process memory space and there is no such thing as shared resources
+  # between child processes and the parent process.  Without implementing a need using inter process communication with
+  # IO::Pipe, only the PID is of any use for the parent process.
+  # To summarize, if using forks, the parent process will only have a collection of PIDS and not any threads
+  # associated with those PIDS.
   class WorkerStatus
+
+    # List of WorkerProcess
     attr_reader :processes
+
     def initialize
       @processes = Concurrent::Array.new
     end
 
+    # Retrieve a simple list of all threads.
+    # Important Note:  The list of threads is only relevant to the current process.
     def threads
       list = []
       @processes.each do |p|
@@ -21,6 +33,7 @@ module EventQ
     end
   end
 
+  # Class that is used to represent a process and its associated threads.
   class WorkerProcess
     attr_accessor :pid
     attr_reader :threads

--- a/spec/eventq_aws/integration/aws_queue_worker_spec.rb
+++ b/spec/eventq_aws/integration/aws_queue_worker_spec.rb
@@ -88,7 +88,8 @@ RSpec.describe EventQ::Amazon::QueueWorker, integration: true do
         sleep 3
         expect(queue_worker.worker_status.processes.count).to eq 3
         expect(queue_worker.worker_status.processes.map(&:pid)).to_not include Process.pid
-        # expect(queue_worker.worker_status.threads.count).to eq 3
+        # when using forks we can't track threads from main parent worker process
+        expect(queue_worker.worker_status.threads.count).to eq 0
       end
     end
 

--- a/spec/eventq_aws/integration/aws_queue_worker_spec.rb
+++ b/spec/eventq_aws/integration/aws_queue_worker_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe EventQ::Amazon::QueueWorker, integration: true do
         sleep 3
         expect(queue_worker.worker_status.processes.count).to eq 3
         expect(queue_worker.worker_status.processes.map(&:pid)).to_not include Process.pid
-        expect(queue_worker.worker_status.threads.count).to eq 3
+        # expect(queue_worker.worker_status.threads.count).to eq 3
       end
     end
 


### PR DESCRIPTION
Got rid of the unnecessary inter-process communication via IO::Pipe.  Some timing issue around marshaling in order to simply get a list of "String" threads in order to know the count from the main process.
This *implies* that the main process will not know about the count of threads in each fork, but since it can't do anything with it in the first place, it is not necessary.
Main parent process will just build the list of processes from the fork loop.

Fixed issue around Oj deserialization.  Appears something "up" with `activesupport ~> 5` and `Oj` and `DateTime`.  Locked to `~> 4` for now in gemspec.