### PR TITLE
add more info to the log

### DIFF
--- a/lib/eventq/queue_worker.rb
+++ b/lib/eventq/queue_worker.rb
@@ -149,7 +149,13 @@ module EventQ
       rescue => e
         EventQ.logger.error do
           "[#{self.class}] - Unhandled error while attempting to process a queue message. - #{e.message}" \
-          "#{e.backtrace.join("\n")}"
+          " - message.id: #{message.id}" \
+          " - message.created: #{message.created}" \
+          " - message.type: #{message.type}" \
+          " - message.content: #{message.content}" \
+          " - message.content_type: #{message.content_type}" \
+          " - message.context: #{message.context}" \
+          " - backtrace: #{e.backtrace.join("\n")}"
         end
 
         error = true


### PR DESCRIPTION
Added a bit more info to the error log so that it is easier for us to know what the error was.

By running the specs I was able to see what to expect in case of error:
```
E, [2018-11-28T13:55:16.746974 #1407] ERROR -- : [EventQ::QueueWorker] - Unhandled error while attempting to process a queue message. - Fail on purpose to send event to retry queue. - message.id: b19630e8-ae02-4f5d-8f0c-6277a53ca5fd - message.created: 1543413315.62569 - message.type: queue_worker_event1_341e - message.content: Hello World - message.content_type: String - message.context: {} - backtrace: /src/spec/eventq_aws/integration/aws_queue_worker_spec.rb:307:in `block (4 levels) in <top (required)>'
/src/lib/eventq/queue_worker.rb:138:in `process_message'
```