### PR TITLE
Allow queue name to have a custom namespace delimiter

### DIFF
--- a/lib/eventq.rb
+++ b/lib/eventq.rb
@@ -4,6 +4,7 @@ require 'class_kit'
 require 'hash_kit'
 require 'oj'
 
+require_relative 'eventq/base'
 require_relative 'eventq/eventq_base/eventq_logger'
 require_relative 'eventq/eventq_base/queue'
 require_relative 'eventq/eventq_base/exchange'

--- a/lib/eventq/aws.rb
+++ b/lib/eventq/aws.rb
@@ -12,23 +12,5 @@ require_relative './eventq_aws/aws_status_checker'
 require_relative './eventq_aws/aws_queue_worker'
 
 module EventQ
-  def self.namespace
-    @namespace
-  end
-  def self.namespace=(value)
-    @namespace = value
-  end
-  def self.create_event_type(event_type)
-    if EventQ.namespace == nil
-      return event_type
-    end
-    return "#{EventQ.namespace}-#{event_type}"
-  end
-  def self.create_queue_name(queue_name)
-    if EventQ.namespace == nil
-      return queue_name
-    end
-    return "#{EventQ.namespace}-#{queue_name}"
-  end
 end
 

--- a/lib/eventq/base.rb
+++ b/lib/eventq/base.rb
@@ -1,0 +1,23 @@
+module EventQ
+  def self.namespace
+    @namespace
+  end
+
+  def self.namespace=(value)
+    @namespace = value
+  end
+
+  def self.create_event_type(event_type)
+    if EventQ.namespace == nil
+      return event_type
+    end
+    return "#{EventQ.namespace}-#{event_type}"
+  end
+
+  def self.create_queue_name(queue)
+    return queue.name if EventQ.namespace == nil
+
+    delimiter = queue.namespace_delimiter || '-'
+    return "#{EventQ.namespace}#{delimiter}#{queue.name}"
+  end
+end

--- a/lib/eventq/eventq_aws/sqs.rb
+++ b/lib/eventq/eventq_aws/sqs.rb
@@ -15,7 +15,7 @@ module EventQ
 
       # Create a new queue.
       def create_queue(queue, attributes = {})
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
 
         url = get_queue_url(queue)
         unless url
@@ -50,7 +50,7 @@ module EventQ
       # @param queue [EventQ::Queue]
       # @return ARN [String]
       def get_queue_arn(queue)
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
 
         arn = @@queue_arns[_queue_name]
         unless arn
@@ -74,7 +74,7 @@ module EventQ
       # @param queue [EventQ::Queue]
       # @return URL [String]
       def get_queue_url(queue)
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
 
         url = @@queue_urls[_queue_name]
         unless url
@@ -97,7 +97,7 @@ module EventQ
         q = get_queue_url(queue)
         sqs.delete_queue(queue_url: q)
 
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
         @@queue_urls.delete(_queue_name)
         @@queue_arns.delete(_queue_name)
 

--- a/lib/eventq/eventq_base/exchange.rb
+++ b/lib/eventq/eventq_base/exchange.rb
@@ -1,5 +1,6 @@
 module EventQ
   class Exchange
     attr_accessor :name
+    attr_accessor :namespace_delimiter
   end
 end

--- a/lib/eventq/eventq_base/queue.rb
+++ b/lib/eventq/eventq_base/queue.rb
@@ -11,6 +11,7 @@ module EventQ
     attr_accessor :retry_delay
     attr_accessor :retry_back_off_grace
     attr_accessor :retry_back_off_weight
+    attr_accessor :namespace_delimiter
 
     def initialize
       @allow_retry = false

--- a/lib/eventq/eventq_rabbitmq/rabbitmq_eventq_client.rb
+++ b/lib/eventq/eventq_rabbitmq/rabbitmq_eventq_client.rb
@@ -81,7 +81,7 @@ module EventQ
           delay_queue = @queue_manager.create_delay_queue(channel, queue, exchange.name, delay)
           delay_queue.bind(delay_exchange, routing_key: _event_type)
 
-          _queue_name = EventQ.create_queue_name(queue.name)
+          _queue_name = EventQ.create_queue_name(queue)
 
           q = channel.queue(_queue_name, durable: @queue_manager.durable)
           q.bind(exchange, routing_key: _event_type)

--- a/lib/eventq/eventq_rabbitmq/rabbitmq_queue_manager.rb
+++ b/lib/eventq/eventq_rabbitmq/rabbitmq_queue_manager.rb
@@ -14,7 +14,7 @@ module EventQ
 
       def get_queue(channel, queue)
 
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
 
         # get/create the queue
         q = channel.queue(_queue_name, :durable => @durable)
@@ -41,29 +41,29 @@ module EventQ
       end
 
       def get_queue_exchange(channel, queue)
-        _exchange_name = EventQ.create_exchange_name(queue.name)
+        _exchange_name = EventQ.create_exchange_name(queue)
         channel.fanout("#{_exchange_name}.ex")
       end
 
       def get_retry_exchange(channel, queue)
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
         return channel.fanout("#{_queue_name}.r.ex")
       end
 
       def get_subscriber_exchange(channel, queue)
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
         return channel.fanout("#{_queue_name}.ex")
       end
 
       def get_delay_exchange(channel, queue, delay)
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
         channel.direct("#{_queue_name}.#{delay}.d.ex")
       end
 
       def get_retry_queue(channel, queue)
         subscriber_exchange = get_subscriber_exchange(channel, queue)
 
-        _queue_name = EventQ.create_queue_name(queue.name)
+        _queue_name = EventQ.create_queue_name(queue)
 
         if queue.allow_retry_back_off == true
 
@@ -82,13 +82,13 @@ module EventQ
       end
 
       def create_delay_queue(channel, queue, dlx_name, delay=0)
-        queue_name = EventQ.create_queue_name(queue.name)
+        queue_name = EventQ.create_queue_name(queue)
         channel.queue("#{queue_name}.#{delay}.delay", durable: @durable,
                       arguments: { X_DEAD_LETTER_EXCHANGE => dlx_name, X_MESSAGE_TTL => delay * 1000 })
       end
 
       def get_exchange(channel, exchange)
-        _exchange_name = EventQ.create_exchange_name(exchange.name)
+        _exchange_name = EventQ.create_exchange_name(exchange)
         return channel.direct(_exchange_name, :durable => @durable)
       end
     end

--- a/lib/eventq/eventq_rabbitmq/rabbitmq_status_checker.rb
+++ b/lib/eventq/eventq_rabbitmq/rabbitmq_status_checker.rb
@@ -27,7 +27,7 @@ module EventQ
         begin
           connection = @client.get_connection
           channel = connection.create_channel
-          _queue_name = EventQ.create_queue_name(queue.name)
+          _queue_name = EventQ.create_queue_name(queue)
           channel.queue(_queue_name, :durable => true)
         rescue
           outcome = false

--- a/lib/eventq/queue_worker.rb
+++ b/lib/eventq/queue_worker.rb
@@ -30,7 +30,7 @@ module EventQ
       configure(queue, options)
       worker_adapter.configure(options)
 
-      queue_name = EventQ.create_queue_name(queue.name)
+      queue_name = EventQ.create_queue_name(queue)
       EventQ.logger.info("[#{self.class}] - Listening for messages on queue: #{queue_name}}")
 
       # Allow the worker to be started on a thread or on the main process.

--- a/lib/eventq/rabbitmq.rb
+++ b/lib/eventq/rabbitmq.rb
@@ -1,41 +1,16 @@
-# require 'eventq_base'
-
 require 'bunny'
 
 require 'hash_kit'
 require_relative './eventq_rabbitmq/rabbitmq_queue_client'
 require_relative './eventq_rabbitmq/rabbitmq_queue_manager'
-
 require_relative './eventq_rabbitmq/rabbitmq_queue_worker'
-
 require_relative './eventq_rabbitmq/rabbitmq_subscription_manager'
 require_relative './eventq_rabbitmq/rabbitmq_eventq_client'
 require_relative './eventq_rabbitmq/default_queue'
 require_relative './eventq_rabbitmq/rabbitmq_status_checker'
 
 module EventQ
-  def self.namespace
-    @namespace
-  end
-  def self.namespace=(value)
-    @namespace = value
-  end
-  def self.create_event_type(event_type)
-    if EventQ.namespace == nil
-      return event_type
-    end
-    return "#{EventQ.namespace}-#{event_type}"
-  end
-  def self.create_queue_name(queue_name)
-    if EventQ.namespace == nil
-      return queue_name
-    end
-    return "#{EventQ.namespace}-#{queue_name}"
-  end
-  def self.create_exchange_name(exchange_name)
-    if EventQ.namespace == nil
-      return exchange_name
-    end
-    return "#{EventQ.namespace}-#{exchange_name}"
+  def self.create_exchange_name(exchange)
+    create_queue_name(exchange)
   end
 end

--- a/spec/eventq_base/base_spec.rb
+++ b/spec/eventq_base/base_spec.rb
@@ -1,0 +1,21 @@
+require 'spec_helper'
+
+RSpec.describe EventQ do
+  describe '#create_queue_name' do
+    let(:queue) { EventQ::Queue.new }
+
+    before do
+      queue.name = 'bogus_queue'
+      allow(EventQ).to receive(:namespace) { 'test' }
+    end
+
+    it 'creates the queue name with a default delimiter' do
+      expect(EventQ.create_queue_name(queue)).to eq 'test-bogus_queue'
+    end
+
+    it 'allows the queue name to have a custom delimeter' do
+      queue.namespace_delimiter = '++'
+      expect(EventQ.create_queue_name(queue)).to eq 'test++bogus_queue'
+    end
+  end
+end


### PR DESCRIPTION
Allow the queue delimiter used between the namespace and queue name to be customized.  A new attribute on the Queue class called `namespace_delimiter` is an optional setting. The default will remain a dash, '-'.

This is primarily to be able to support creating a subscription between an event and queue (i.e. SQS and SNS), whereby the queue processing is handled by an external worker outside of `EventQ`.