### PR TITLE
Allow queue to define that topic will not be auto created.

### DIFF
--- a/lib/eventq/eventq_aws/aws_subscription_manager.rb
+++ b/lib/eventq/eventq_aws/aws_subscription_manager.rb
@@ -20,17 +20,13 @@ module EventQ
         end
 
         topic_arn = @client.sns_helper(topic_region).public_send(method, event_type, topic_region)
+        raise Exceptions::EventTypeNotFound, 'SNS topic not found, unable to subscribe' unless topic_arn
 
         q = @manager.get_queue(queue)
         queue_arn = @client.sqs_helper(queue_region).get_queue_arn(queue)
 
-        @client.sqs(queue_region).set_queue_attributes(
-          queue_url: q,
-          attributes:
-            {
-              'Policy' => queue_policy(queue_arn)
-            }
-        )
+        attributes = default_queue_attributes(q, queue_arn)
+        @client.sqs(queue_region).set_queue_attributes(attributes)
 
         @client.sns(topic_region).subscribe(
           topic_arn: topic_arn,
@@ -47,6 +43,18 @@ module EventQ
 
       def unsubscribe(_queue)
         raise "[#{self.class}] - Not implemented. Please unsubscribe the queue from the topic inside the AWS Management Console."
+      end
+
+      private
+
+      def default_queue_attributes(queue, queue_arn)
+        {
+          queue_url: queue,
+          attributes:
+            {
+              'Policy' => queue_policy(queue_arn)
+            }
+        }
       end
 
       def queue_policy(queue_arn)

--- a/lib/eventq/eventq_aws/aws_subscription_manager.rb
+++ b/lib/eventq/eventq_aws/aws_subscription_manager.rb
@@ -13,7 +13,13 @@ module EventQ
       end
 
       def subscribe(event_type, queue, topic_region = nil, queue_region = nil)
-        topic_arn = @client.sns_helper(topic_region).create_topic_arn(event_type, topic_region)
+        if queue.isolated
+          method = :get_topic_arn
+        else
+          method = :create_topic_arn
+        end
+
+        topic_arn = @client.sns_helper(topic_region).public_send(method, event_type, topic_region)
 
         q = @manager.get_queue(queue)
         queue_arn = @client.sqs_helper(queue_region).get_queue_arn(queue)

--- a/lib/eventq/eventq_base/exceptions.rb
+++ b/lib/eventq/eventq_base/exceptions.rb
@@ -1,2 +1,3 @@
 require_relative 'exceptions/invalid_signature_exception'
 require_relative 'exceptions/worker_thread_error'
+require_relative 'exceptions/event_type_not_found'

--- a/lib/eventq/eventq_base/exceptions/event_type_not_found.rb
+++ b/lib/eventq/eventq_base/exceptions/event_type_not_found.rb
@@ -1,0 +1,12 @@
+module EventQ
+  module Exceptions
+    # Error for when an event type is not found by the relevant adapters
+    # For AWS SNS that would be a Topic
+    # For RabbitMq that would be an Exchange.
+    class EventTypeNotFound < StandardError
+      def initialize(message)
+        super(message)
+      end
+    end
+  end
+end

--- a/lib/eventq/eventq_base/queue.rb
+++ b/lib/eventq/eventq_base/queue.rb
@@ -11,6 +11,8 @@ module EventQ
     attr_accessor :retry_delay
     attr_accessor :retry_back_off_grace
     attr_accessor :retry_back_off_weight
+    # Flag to control that the queue runs in isolation of auto creating the topic it belongs to
+    attr_accessor :isolated
 
     def initialize
       @allow_retry = false
@@ -30,6 +32,7 @@ module EventQ
       @retry_back_off_grace = 0
       # Multiplier for the backoff retry in case retry_delay is too small
       @retry_back_off_weight = 1
+      @isolated = false
     end
   end
 end

--- a/spec/eventq_aws/aws_subscription_manager_spec.rb
+++ b/spec/eventq_aws/aws_subscription_manager_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe EventQ::Amazon::SubscriptionManager do
+  subject { described_class.new(client: queue_client, queue_manager: queue_manager) }
+
+  let(:queue_client) do
+    EventQ::Amazon::QueueClient.new
+  end
+
+  let(:queue_manager) do
+    EventQ::Amazon::QueueManager.new({ client: queue_client })
+  end
+
+  let(:subscriber_queue) do
+    EventQ::Queue.new.tap do |sq|
+      sq.name = SecureRandom.uuid.to_s
+    end
+  end
+
+  let(:event_type) { SecureRandom.uuid }
+
+  describe '#subscribe' do
+    context 'when Queue.isolated is false' do
+      it 'creates a topic if it does not exist' do
+        expect { subject.subscribe(event_type, subscriber_queue) }.to_not raise_error
+      end
+    end
+
+    context 'when Queue.isolated is true' do
+      it 'raises an error if topic does not exist' do
+        subscriber_queue.isolated = true
+        expect { subject.subscribe(event_type, subscriber_queue) }.to raise_error
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allow the ability to create a queue and subscribe to a topic without creating the topic.  This assumes an external service was responsible for owning the topic outside of Eventq and alleviates the risk of creating a topic that is incorrect where the owner actually publishes to the correct one.

