### PR TITLE
Use the SNS helper to create the topic to filter out invalid characters for AWS

### DIFF
--- a/lib/eventq/eventq_aws/aws_subscription_manager.rb
+++ b/lib/eventq/eventq_aws/aws_subscription_manager.rb
@@ -29,7 +29,7 @@ module EventQ
           namespaced_topic_arn = topic_arn.gsub(":#{EventQ.namespace}-", ":#{namespace}-")
 
           # create the sns topic - this method is idempotent & returns the topic arn if it already exists
-          @client.sns.create_topic(name: "#{namespace}-#{event_type}".delete('.')) unless queue.isolated
+          @client.sns_helper.create_topic_arn("#{namespace}-#{event_type}".delete('.')) unless queue.isolated
 
           # skip subscribe if subscription for given queue/topic already exists
           # this is a workaround for a localstack issue: https://github.com/localstack/localstack/issues/933

--- a/spec/eventq_aws/aws_subscription_manager_spec.rb
+++ b/spec/eventq_aws/aws_subscription_manager_spec.rb
@@ -97,7 +97,7 @@ RSpec.describe EventQ::Amazon::SubscriptionManager do
           protocol: 'sqs',
           endpoint: queue_arn
         )
-        expect_any_instance_of(Aws::SNS::Client).to receive(:create_topic).exactly(3).times
+        expect_any_instance_of(EventQ::Amazon::SNS).to receive(:create_topic_arn).exactly(3).times
         subject.subscribe(event_type, subscriber_queue, nil, nil, namespaces)
       end
 


### PR DESCRIPTION
Use the SNS helper to create the topic, so that the topic name gets passed through the `#aws_safe_name` method to remove any invalid characters.

Update the spec to verify that `#create_topic_arn` is called instead of `#create_topic`.