### PR TITLE
Include the event type in EventTypeNotFound error message

### DIFF
--- a/lib/eventq/eventq_aws/aws_subscription_manager.rb
+++ b/lib/eventq/eventq_aws/aws_subscription_manager.rb
@@ -20,7 +20,7 @@ module EventQ
         end
 
         topic_arn = @client.sns_helper(topic_region).public_send(method, event_type, topic_region)
-        raise Exceptions::EventTypeNotFound, 'SNS topic not found, unable to subscribe' unless topic_arn
+        raise Exceptions::EventTypeNotFound, "SNS topic not found, unable to subscribe to #{event_type}" unless topic_arn
 
         queue_arn = configure_queue(queue, queue_region)
 


### PR DESCRIPTION
When raising an `EventTypeNotFound` error, include the event type in the error message to make debugging a bit easier.