### PR TITLE
Handle paging when listing topics

### DIFF
--- a/lib/eventq/eventq_aws/sns.rb
+++ b/lib/eventq/eventq_aws/sns.rb
@@ -71,7 +71,7 @@ module EventQ
       # we'll need to request each page of topics using response.next_token for
       # until the response no longer contains a next_token. Requests to
       # list_topics are throttled to 30 TPS, so in the future we may need to
-      # handle 429 responses if this becomes a problem.
+      # handle this if it becomes a problem.
       #
       # @param topic_name [String] the name of the topic to find
       # @return [String]

--- a/lib/eventq/eventq_aws/sns.rb
+++ b/lib/eventq/eventq_aws/sns.rb
@@ -70,7 +70,8 @@ module EventQ
       # @note Responses to list_topics can be paged, so to check *all* topics
       # we'll need to request each page of topics using response.next_token for
       # until the response no longer contains a next_token. Requests to
-      # list_topics are throttled to 30 TPS, so we need to play nicely.
+      # list_topics are throttled to 30 TPS, so in the future we may need to
+      # handle 429 responses if this becomes a problem.
       #
       # @param topic_name [String] the name of the topic to find
       # @return [String]
@@ -83,8 +84,6 @@ module EventQ
           response = sns.list_topics(next_token: response.next_token)
           topics = response.topics
           arn = topics.detect { |topic| topic.topic_arn.end_with?(":#{topic_name}") }&.topic_arn
-
-          sleep 0.5
         end
 
         arn

--- a/lib/eventq/eventq_aws/sns.rb
+++ b/lib/eventq/eventq_aws/sns.rb
@@ -33,11 +33,6 @@ module EventQ
 
       # Check if a TopicArn exists.  This will check with AWS if necessary and cache the results if one is found
       #
-      # @note Responses to list_topics can be paged, so to check *all* topics
-      # we'll need to request each page of topics using response.next_token for
-      # until the response no longer contains a next_token. Requests to
-      # list_topics are throttled to 30 TPS, so we need to play nicely.
-      #
       # @return TopicArn [String]
       def get_topic_arn(event_type, region = nil)
         _event_type = EventQ.create_event_type(event_type)
@@ -45,14 +40,7 @@ module EventQ
 
         arn = @@topic_arns[topic_key]
         unless arn
-          response = sns.list_topics
-          topics = response.topics
-          while response.next_token
-            response = sns.list_topics(next_token: response.next_token)
-            topics << response.topics
-            sleep 0.5
-          end
-          arn = topics.detect { |topic| topic.topic_arn.end_with?(":#{_event_type}") }&.topic_arn
+          arn = find_topic(_event_type)
 
           @@topic_arns[topic_key] = arn if arn
         end
@@ -73,6 +61,33 @@ module EventQ
 
       def aws_safe_name(name)
         return name[0..79].gsub(/[^a-zA-Z\d_\-]/,'')
+      end
+
+      private
+
+      # Finds the given topic, or returns nil if the topic could not be found
+      #
+      # @note Responses to list_topics can be paged, so to check *all* topics
+      # we'll need to request each page of topics using response.next_token for
+      # until the response no longer contains a next_token. Requests to
+      # list_topics are throttled to 30 TPS, so we need to play nicely.
+      #
+      # @param topic_name [String] the name of the topic to find
+      # @return [String]
+      def find_topic(topic_name)
+        response = sns.list_topics
+        topics = response.topics
+        arn = topics.detect { |topic| topic.topic_arn.end_with?(":#{topic_name}") }&.topic_arn
+
+        while arn.nil? && response.next_token
+          response = sns.list_topics(next_token: response.next_token)
+          topics = response.topics
+          arn = topics.detect { |topic| topic.topic_arn.end_with?(":#{topic_name}") }&.topic_arn
+
+          sleep 0.5
+        end
+
+        arn
       end
     end
   end


### PR DESCRIPTION
Calls to `#list_topics` can return paged results. When this happens the
response includes a `next_token` which we can use to request the next
page.

This PR updates `#get_topic_arn` to check for a `next_token` when making
calls to `#list_topics`. It searches each page of results for the given topic 
before requesting the next page.

Note that, according to the AWS docs, calls to `#list_topics` are
throttled to 30 TPS. Therefore we call `sleep` between requests to make
sure we play nicely.