### PR TITLE
Return topic arns when registering SNS topics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,4 @@ platforms :ruby do
   gem 'oj', '3.6.10'
   gem 'openssl', '2.1.1'
   gem 'bunny'
-  gem 'pry-byebug'
-  gem 'byebug', '10.0.2'
 end

--- a/eventq.gemspec
+++ b/eventq.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'pry-byebug', '~> 3.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'simplecov'

--- a/eventq.gemspec
+++ b/eventq.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency 'activesupport', '~> 4'
   spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'byebug', '~> 11.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'

--- a/eventq.gemspec
+++ b/eventq.gemspec
@@ -19,19 +19,19 @@ Gem::Specification.new do |spec|
   spec.files         = ["README.md"] + Dir.glob("{bin,lib}/**/**/**")
   spec.require_paths = ["lib"]
 
+  spec.add_development_dependency 'activesupport', '~> 4'
   spec.add_development_dependency 'bundler', '~> 1.11'
   spec.add_development_dependency 'pry-byebug', '~> 3.9'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec'
-  spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'shoulda-matchers'
-  spec.add_development_dependency 'activesupport', '~> 4'
+  spec.add_development_dependency 'simplecov'
 
   spec.add_dependency 'aws-sdk', '~> 2.0'
+  spec.add_dependency 'bunny'
   spec.add_dependency 'class_kit'
-  spec.add_dependency 'redlock'
-  spec.add_dependency 'openssl'
   spec.add_dependency 'concurrent-ruby'
   spec.add_dependency 'oj'
-  spec.add_dependency 'bunny'
+  spec.add_dependency 'openssl'
+  spec.add_dependency 'redlock'
 end

--- a/lib/eventq/eventq_aws/aws_eventq_client.rb
+++ b/lib/eventq/eventq_aws/aws_eventq_client.rb
@@ -21,19 +21,16 @@ module EventQ
         @known_event_types = {}
       end
 
-      # Returns the topic arn for event_type if it has already been registered,
-      # or false if it hasn't.
+      # Returns true if the event has already been registerd, or false
+      # otherwise.
       #
       # @param [String] event_type
       # @param [String] region
       #
-      # @return [String] if the event_type is already registered
-      # @return [Boolean] if the event_type is not registered
+      # @return [Boolean]
       def registered?(event_type, region = nil)
         topic_key = "#{region}:#{event_type}"
-        return false unless @known_event_types.key?(topic_key)
-
-        @known_event_types[topic_key]
+        @known_event_types.key?(topic_key)
       end
 
       # Registers the event event_type and returns its topic arn.
@@ -43,10 +40,9 @@ module EventQ
       #
       # @return [String]
       def register_event(event_type, region = nil)
-        topic_arn = registered?(event_type, region)
-        return topic_arn if topic_arn
-
         topic_key = "#{region}:#{event_type}"
+        return @known_event_types[topic_key] if registered?(event_type, region)
+
         topic_arn = @client.sns_helper(region).create_topic_arn(event_type, region)
         @known_event_types[topic_key] = topic_arn
         topic_arn

--- a/spec/eventq_aws/aws_eventq_client_spec.rb
+++ b/spec/eventq_aws/aws_eventq_client_spec.rb
@@ -110,8 +110,8 @@ RSpec.describe EventQ::Amazon::EventQClient do
         known_types[":#{event_type}"] = topic_arn
       end
 
-      it 'should return the topic arn' do
-        expect(subject.registered?(event_type)).to eq topic_arn
+      it 'should return true' do
+        expect(subject.registered?(event_type)).to be true
       end
     end
 


### PR DESCRIPTION
Update the AWS `EventQClient#regiser_event` to return the topic arn of
the topic it registers.

Update the `#registered?` method too: if an event is already registered
then return its topic arn, otherwise return false.

Internally the `@known_event_types` has been changed from an array to
a hash. The existing topic key that was stored in the array is used as
the key, and the topic arn as the value.