### PR TITLE
Use port 4566 for all things localstack

### DIFF
--- a/script/docker-compose.yml
+++ b/script/docker-compose.yml
@@ -18,8 +18,8 @@ services:
       - AWS_ACCESS_KEY_ID=mock_id
       - AWS_SECRET_ACCESS_KEY=mock_password
       - AWS_REGION=eu-west-1
-      - AWS_SQS_ENDPOINT=http://goaws:4576
-      - AWS_SNS_ENDPOINT=http://goaws:4575
+      - AWS_SQS_ENDPOINT=http://goaws:4566
+      - AWS_SNS_ENDPOINT=http://goaws:4566
 #    env_file:
 #      - ../.aws.env
 
@@ -41,10 +41,9 @@ services:
     image: localstack/localstack
     container_name: goaws
     environment:
-      - SERVICES=sqs:4576,sns:4575
+      - SERVICES=sqs:4566,sns:4566
       - HOSTNAME=goaws
       - HOSTNAME_EXTERNAL=goaws
     ports:
       - "8085:8080"
-      - "4576:4576"
-      - "4575:4575"
+      - "4566:4566"


### PR DESCRIPTION
Using the old service specific ports for SNS and SQS led to spec failures, as later versions of localstack only use port 4566.