### PR TITLE
List topics rate limit retry on error

### DIFF
--- a/lib/eventq/eventq_aws/sns.rb
+++ b/lib/eventq/eventq_aws/sns.rb
@@ -87,6 +87,10 @@ module EventQ
         end
 
         arn
+      rescue Aws::SNS::Errors::Throttling => error
+        EventQ.logger.error("[#{self.class}] - #find_topic: #{error.message}} - retrying in 2s")
+        sleep 2
+        find_topic(topic_name)
       end
     end
   end


### PR DESCRIPTION
When performing a production deployment the error has been spotted 

```
[Aws::SNS::Errors::Throttling]
Error message: Rate exceeded

…3.170.0/lib/seahorse/client/plugins/raise_response_errors.rb:17:in `call'
…-core-3.170.0/lib/aws-sdk-core/plugins/checksum_algorithm.rb:111:in `call'
…core-3.170.0/lib/aws-sdk-core/plugins/jsonvalue_converter.rb:16:in `call'
…k-core-3.170.0/lib/aws-sdk-core/plugins/idempotency_token.rb:19:in `call'
…sdk-core-3.170.0/lib/aws-sdk-core/plugins/param_converter.rb:26:in `call'
…core-3.170.0/lib/seahorse/client/plugins/request_callback.rb:71:in `call'
…sdk-core-3.170.0/lib/aws-sdk-core/plugins/response_paging.rb:12:in `call'
…-core-3.170.0/lib/seahorse/client/plugins/response_target.rb:24:in `call'
…dle/gems/aws-sdk-core-3.170.0/lib/seahorse/client/request.rb:72:in `send_request'
…cal/bundle/gems/aws-sdk-sns-1.59.0/lib/aws-sdk-sns/client.rb:1604:in `list_topics'
…/local/bundle/gems/eventq-3.3.0/lib/eventq/eventq_aws/sns.rb:79:in `find_topic'
…/local/bundle/gems/eventq-3.3.0/lib/eventq/eventq_aws/sns.rb:43:in `get_topic_arn'
…/local/bundle/gems/eventq-3.3.0/lib/eventq/eventq_aws/sns.rb:24:in `create_topic_arn'
…gems/eventq-3.3.0/lib/eventq/eventq_aws/aws_eventq_client.rb:46:in `register_event'
…gems/eventq-3.3.0/lib/eventq/eventq_aws/aws_eventq_client.rb:56:in `raise_event'
…gems/eventq-3.3.0/lib/eventq/eventq_aws/aws_eventq_client.rb:52:in `publish'
```

Documentation
[Amazon Simple Notification Service endpoints and quotas - AWS General Reference](https://docs.aws.amazon.com/general/latest/gr/sns.html)