### PR TITLE
Reduce calls to list-topics

### DIFF
--- a/eventq.gemspec
+++ b/eventq.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency 'activesupport', '~> 4'
-  spec.add_development_dependency 'bundler', '~> 1.11'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug', '~> 11.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.9'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/eventq/eventq_aws/aws_eventq_client.rb
+++ b/lib/eventq/eventq_aws/aws_eventq_client.rb
@@ -53,10 +53,9 @@ module EventQ
       end
 
       def raise_event(event_type, event, context = {}, region = nil)
-        register_event(event_type, region)
+        topic_arn = register_event(event_type, region)
 
         with_prepared_message(event_type, event, context) do |message|
-          topic_arn = topic_arn(event_type, region)
           response = @client.sns(region).publish(
             topic_arn: topic_arn,
             message: message,
@@ -123,10 +122,6 @@ module EventQ
         serialization_provider = @serialization_manager.get_provider(EventQ::Configuration.serialization_provider)
 
         serialization_provider.serialize(queue_message)
-      end
-
-      def topic_arn(event_type, region = nil)
-        @client.sns_helper(region).get_topic_arn(event_type, region)
       end
 
       def sqs_message_body_for(payload_message)

--- a/lib/eventq/eventq_aws/sns.rb
+++ b/lib/eventq/eventq_aws/sns.rb
@@ -21,7 +21,7 @@ module EventQ
         _event_type = EventQ.create_event_type(event_type)
         topic_key = "#{region}:#{_event_type}"
 
-        arn = get_topic_arn(event_type, region)
+        arn = @@topic_arns[topic_key]
         unless arn
           response = sns.create_topic(name: aws_safe_name(_event_type))
           arn = response.topic_arn

--- a/script/Dockerfile
+++ b/script/Dockerfile
@@ -10,5 +10,4 @@ RUN set -ex \
 	&& gem install -N oj --version "3.6.10" \
 	&& gem install -N openssl --version "2.1.1" \
 	&& gem install -N byebug --version "10.0.2" \
-	&& gem install -N pry-byebug \
 	&& apk del .gem-builddeps


### PR DESCRIPTION
Since ListTopics only returns topics in batches of 100 and it gets rate limited, reduce paths that would call this API endpoint.

- Get the topic ARN from elsewhere.
- Call CreateTopic (which is idempotent) and use the returned ARN.