### PR TITLE
Pin AWS SDK versions until we properly upgraded `eventq`

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ class DataChangeAddressQueue < Queue
   def initialize
     @name = 'Data.Change.Address'
     @allow_retry = true
-    @retry_delay = 20000
+    @retry_delay = 20_000
     @max_retry_attempts = 3
   end
 end
@@ -109,10 +109,10 @@ This method is called to unsubscribe a queue.
 
 **Example**
 
-    #create an instant of the queue definition
+    #create an instance of the queue definition
 	queue = DateChangeAddressQueue.new
 
-    #subscribe the queue definition to an event type
+    #unsubscribe the queue definition
     subscription_manager.unsubscribe(queue)
 
 

--- a/eventq.gemspec
+++ b/eventq.gemspec
@@ -24,8 +24,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'shoulda-matchers'
   spec.add_development_dependency 'simplecov', '< 0.18.0'
 
-  spec.add_dependency 'aws-sdk-sqs', '~> 1'
-  spec.add_dependency 'aws-sdk-sns', '~> 1'
+  spec.add_dependency 'aws-sdk-sqs', '~> 1.65.0'
+  spec.add_dependency 'aws-sdk-sns', '~> 1.68.0'
+  spec.add_dependency 'aws-sdk-core', '3.187.0'
   spec.add_dependency 'bunny'
   spec.add_dependency 'class_kit'
   spec.add_dependency 'concurrent-ruby'


### PR DESCRIPTION
In the past month, AWS released backward incompatible changes to `aws-sdk-core` and `aws-sdk-sqs`. We will need to upgrade `eventq` soon, as the changes will be enforced beginning next year.

`aws-sdk-core` released 3.187.1 which changed the default response to an empty list, instead of `nil`. Also, 3.188.0 drops support for Ruby 2.4 & 2.5, which is currently the default for `eventq` during test runs. For more details see:
https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-core/CHANGELOG.md#31871-2023-11-20

`aws-sdk-sqs` released 1.66.0 which switches to using a JSON protocol we have not adjusted to yet. So we need to use a lower version until we upgrade. You can find the release details here:
https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-sqs/CHANGELOG.md#1660-2023-11-08

`aws-sdk-sns` released new versions related to new `aws-sdk-core` releases, which align with 3.188.0 and higher. But that version drops Ruby 2.4 support as detailed above, so need to stick with a lower version until we upgraded to a newer Ruby version. You can find the changelog here:
https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-sns/CHANGELOG.md#1680-2023-10-26