### PR TITLE
Bump dependencies to close vulnerabilities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,11 @@ source 'https://rubygems.org'
 gemspec
 
 
-gem 'json', '2.1.0'
-gem 'redlock'
+gem 'json', '~> 2'
+gem 'redlock', '~> 1'
 
 platforms :ruby do
   gem 'oj', '3.6.10'
-  gem 'openssl', '2.1.1'
+  gem 'openssl', '2.1.2'
   gem 'bunny'
 end

--- a/eventq.gemspec
+++ b/eventq.gemspec
@@ -15,11 +15,11 @@ Gem::Specification.new do |spec|
   spec.files         = ["README.md"] + Dir.glob("{bin,lib}/**/**/**")
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency 'activesupport', '~> 4'
+  spec.add_development_dependency 'activesupport', '~> 6'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'byebug', '~> 11.0'
   spec.add_development_dependency 'pry-byebug', '~> 3.9'
-  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rake', '~> 13'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'shoulda-matchers'
   spec.add_development_dependency 'simplecov', '< 0.18.0'

--- a/script/Dockerfile
+++ b/script/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine3.8
+FROM ruby:2.5-alpine3.8
 
 RUN apk add --update ca-certificates bash && update-ca-certificates && rm -rf /var/cache/apk/*
 RUN apk update && apk add --no-cache build-base
@@ -8,6 +8,6 @@ RUN set -ex \
 		ruby-dev build-base libressl-dev \
 	&& gem install -N json --version "2.1.0" \
 	&& gem install -N oj --version "3.6.10" \
-	&& gem install -N openssl --version "2.1.1" \
+	&& gem install -N openssl --version "2.1.2" \
 	&& gem install -N byebug --version "10.0.2" \
 	&& apk del .gem-builddeps


### PR DESCRIPTION
* Allow `json` to use latest v2 version to get security fixes

* Bump test image to Ruby 2.5, as the Ruby 2.4 `alpine` images do not contain OpenSSL 2.1.2 to close a severe vulnerability.

* Fix `redlock` to v1 as v2 is moving to `redis-client` and does not ship with `redis` anymore, breaking the `NonceManager`.

* Bump `rake` and `activesupport` to new major versions to get security fixes.