### PR TITLE
Add option for exponential back off

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ A subscription queue should be defined to receive any events raised for the subs
 
  - **allow_retry** [Bool] [Optional] [Default=false] This determines if the queue should allow processing failures to be retried.
  - **allow_retry_back_off** [Bool] [Optional] [Default=false] This is used to specify if failed messages that retry should incrementally backoff.
+ - **allow_exponential_back_off** [Bool] [Optional] [Default=false] This is used to specify if failed messages that retry should expontentially backoff.
  - **retry_back_off_grace** [Int] [Optional] [Default=0] This is the number of times to allow retries without applying retry back off if enabled.
  - **dlq** [EventQ::Queue] [Optional] [Default=nil] A queue that will receive the messages which were not successfully processed after maximum number of receives by consumers. This is created at the same time as the parent queue.
  - **max_retry_attempts** [Int] [Optional] [Default=5] This is used to specify the max number of times an event should be allowed to retry before failing.

--- a/lib/eventq/eventq_aws/aws_calculate_visibility_timeout.rb
+++ b/lib/eventq/eventq_aws/aws_calculate_visibility_timeout.rb
@@ -24,7 +24,7 @@ module EventQ
         @retry_attempts = retry_attempts
 
         @allow_retry_back_off       = queue_settings.fetch(:allow_retry_back_off)
-        @allow_exponential_back_off = queue_settings.fetch(:allow_exponential_back_off, false)
+        @allow_exponential_back_off = queue_settings.fetch(:allow_exponential_back_off)
         @max_retry_delay            = queue_settings.fetch(:max_retry_delay)
         @retry_back_off_grace       = queue_settings.fetch(:retry_back_off_grace)
         @retry_back_off_weight      = queue_settings.fetch(:retry_back_off_weight)

--- a/lib/eventq/eventq_aws/aws_queue_worker.rb
+++ b/lib/eventq/eventq_aws/aws_queue_worker.rb
@@ -122,11 +122,12 @@ module EventQ
           visibility_timeout = @calculate_visibility_timeout.call(
             retry_attempts:       retry_attempts,
             queue_settings: {
-              allow_retry_back_off:  queue.allow_retry_back_off,
-              max_retry_delay:       queue.max_retry_delay,
-              retry_back_off_grace:  queue.retry_back_off_grace,
-              retry_back_off_weight: queue.retry_back_off_weight,
-              retry_delay:           queue.retry_delay
+              allow_retry_back_off:       queue.allow_retry_back_off,
+              allow_exponential_back_off: queue.allow_exponential_back_off,
+              max_retry_delay:            queue.max_retry_delay,
+              retry_back_off_grace:       queue.retry_back_off_grace,
+              retry_back_off_weight:      queue.retry_back_off_weight,
+              retry_delay:                queue.retry_delay
             }
           )
 

--- a/lib/eventq/eventq_base/queue.rb
+++ b/lib/eventq/eventq_base/queue.rb
@@ -2,6 +2,7 @@ module EventQ
   class Queue
     attr_accessor :allow_retry
     attr_accessor :allow_retry_back_off
+    attr_accessor :allow_exponential_back_off
     attr_accessor :dlq
     attr_accessor :max_retry_attempts
     attr_accessor :max_retry_delay
@@ -20,6 +21,8 @@ module EventQ
       @allow_retry = false
       # Default retry back off settings
       @allow_retry_back_off = false
+      # Default exponential back off settings
+      @allow_exponential_back_off = false
       # Default max receive count is 30
       @max_receive_count = 30
       # Default max retry attempts is 5

--- a/lib/eventq/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/lib/eventq/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -80,7 +80,12 @@ module EventQ
           retry_attempts = 1 if retry_attempts < 1
 
           if queue.allow_retry_back_off == true
-            message_ttl = retry_attempts * queue.retry_delay
+            message_ttl = if queue.allow_exponential_back_off
+              queue.retry_delay * 2 ** (retry_attempts - 1)
+            else
+              queue.retry_delay * retry_attempts
+            end
+
             if (retry_attempts * queue.retry_delay) > queue.max_retry_delay
               EventQ.logger.debug { "[#{self.class}] - Max message back off retry delay reached." }
               message_ttl = queue.max_retry_delay

--- a/lib/eventq/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/lib/eventq/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -121,7 +121,7 @@ module EventQ
       end
 
       def retry_delay(queue, retry_attempts)
-        return queue.retry_delay unless queue.allow_retry_back_off == true
+        return queue.retry_delay unless queue.allow_retry_back_off
 
         message_ttl = if queue.allow_exponential_back_off
           queue.retry_delay * 2 ** (retry_attempts - 1)

--- a/spec/eventq_aws/aws_calculate_visibility_timeout_spec.rb
+++ b/spec/eventq_aws/aws_calculate_visibility_timeout_spec.rb
@@ -1,11 +1,25 @@
 require 'spec_helper'
 
 RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
+  let(:allow_retry_back_off) { false }
+  let(:allow_exponential_back_off) { false }
+
   let(:max_timeout) { 43_200 }        # 43_200s (12h)
-  let(:retry_delay) { 30_000 }        # 30s
   let(:max_retry_delay) { 100_000 }   # 100s
+  let(:retry_delay) { 30_000 }        # 30s
   let(:retry_back_off_grace) { 1000 } # iterations before the backoff grace quicks in
   let(:retry_back_off_weight) { 1 }   # backoff multiplier
+
+  let(:queue_settings) do
+    {
+      allow_retry_back_off:       allow_retry_back_off,
+      allow_exponential_back_off: allow_exponential_back_off,
+      max_retry_delay:            max_retry_delay,
+      retry_delay:                retry_delay,
+      retry_back_off_grace:       retry_back_off_grace,
+      retry_back_off_weight:      retry_back_off_weight
+    }
+  end
 
   subject { described_class.new(max_timeout: max_timeout) }
 
@@ -14,28 +28,16 @@ RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
 
     it 'does not introduces backoff' do
       result = subject.call(
-        retry_attempts:       1,
-        queue_settings: {
-          allow_retry_back_off:  allow_retry_back_off,
-          max_retry_delay:       max_retry_delay,
-          retry_back_off_grace:  retry_back_off_grace,
-          retry_delay:           retry_delay,
-          retry_back_off_weight: retry_back_off_weight
-        }
+        retry_attempts: 1,
+        queue_settings: queue_settings
       )
 
       expect(result).to eq(ms_to_seconds(retry_delay))
 
 
       result = subject.call(
-        retry_attempts:       retry_back_off_grace + 100,
-        queue_settings: {
-          allow_retry_back_off:  allow_retry_back_off,
-          max_retry_delay:       max_retry_delay,
-          retry_back_off_grace:  retry_back_off_grace,
-          retry_delay:           retry_delay,
-          retry_back_off_weight: retry_back_off_weight
-        }
+        retry_attempts: retry_back_off_grace + 100,
+        queue_settings: queue_settings
       )
 
       expect(result).to eq(ms_to_seconds(retry_delay))
@@ -48,14 +50,8 @@ RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
     context 'when the retry_attempts is lower than the retry_back_off_grace' do
       it 'does not introduce backoff' do
         result = subject.call(
-          retry_attempts:       retry_back_off_grace - 1,
-          queue_settings: {
-            allow_retry_back_off:  allow_retry_back_off,
-            max_retry_delay:       max_retry_delay,
-            retry_back_off_grace:  retry_back_off_grace,
-            retry_delay:           retry_delay,
-            retry_back_off_weight: retry_back_off_weight
-          }
+          retry_attempts: retry_back_off_grace - 1,
+          queue_settings: queue_settings
         )
 
         expect(result).to eq(ms_to_seconds(retry_delay))
@@ -67,14 +63,8 @@ RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
         retries_past_grace_period = 2
 
         result = subject.call(
-          retry_attempts:       retry_back_off_grace + retries_past_grace_period,
-          queue_settings: {
-            allow_retry_back_off:  allow_retry_back_off,
-            max_retry_delay:       max_retry_delay,
-            retry_back_off_grace:  retry_back_off_grace,
-            retry_delay:           retry_delay,
-            retry_back_off_weight: retry_back_off_weight
-          }
+          retry_attempts: retry_back_off_grace + retries_past_grace_period,
+          queue_settings: queue_settings
         )
 
         expect(result).to eq(ms_to_seconds(retry_delay) * retries_past_grace_period)
@@ -84,14 +74,8 @@ RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
     context 'when the visible_timeout exceeds the max_retry_delay' do
       it 'returns the max_retry_delay' do
         result = subject.call(
-          retry_attempts:       retry_back_off_grace + 100_000,
-          queue_settings: {
-            allow_retry_back_off:  allow_retry_back_off,
-            max_retry_delay:       max_retry_delay,
-            retry_back_off_grace:  retry_back_off_grace,
-            retry_delay:           retry_delay,
-            retry_back_off_weight: retry_back_off_weight
-          }
+          retry_attempts: retry_back_off_grace + 100_000,
+          queue_settings: queue_settings
         )
 
         expect(result).to eq(ms_to_seconds(max_retry_delay))
@@ -99,16 +83,12 @@ RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
     end
 
     context 'when the visible_timeout is bigger than max_timeout' do
+      let(:max_retry_delay) { 50_000_000 }
+
       it 'the visible_timeout is set to max_timeout' do
         result = subject.call(
-          retry_attempts:       retry_back_off_grace + 100_000,
-          queue_settings: {
-            allow_retry_back_off:  allow_retry_back_off,
-            max_retry_delay:       50_000_000,
-            retry_back_off_grace:  retry_back_off_grace,
-            retry_delay:           retry_delay,
-            retry_back_off_weight: retry_back_off_weight
-          }
+          retry_attempts: retry_back_off_grace + 100_000,
+          queue_settings: queue_settings
         )
 
         expect(result).to eq(max_timeout)
@@ -116,19 +96,15 @@ RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
     end
 
     context 'when retry_back_off_weight is added' do
+      let(:retry_back_off_weight) { 2 }
+      let(:max_retry_delay) { 1_000_000 }
+
       it 'the backoff is multiplied' do
         retries_past_grace_period = 2
-        retry_back_off_weight = 2
 
         result = subject.call(
-          retry_attempts:       retry_back_off_grace + retries_past_grace_period,
-          queue_settings: {
-            allow_retry_back_off:  allow_retry_back_off,
-            max_retry_delay:       1_000_000,
-            retry_back_off_grace:  retry_back_off_grace,
-            retry_delay:           retry_delay,
-            retry_back_off_weight: retry_back_off_weight
-          }
+          retry_attempts: retry_back_off_grace + retries_past_grace_period,
+          queue_settings: queue_settings
         )
 
         expect(result).to eq(ms_to_seconds(retry_delay) * retries_past_grace_period * retry_back_off_weight)
@@ -143,15 +119,8 @@ RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
         retries_past_grace_period = 10
 
         result = subject.call(
-          retry_attempts:       retry_back_off_grace + retries_past_grace_period,
-          queue_settings: {
-            allow_retry_back_off:       allow_retry_back_off,
-            allow_exponential_back_off: allow_exponential_back_off,
-            max_retry_delay:            max_retry_delay,
-            retry_back_off_grace:       retry_back_off_grace,
-            retry_delay:                retry_delay,
-            retry_back_off_weight:      retry_back_off_weight
-          }
+          retry_attempts: retry_back_off_grace + retries_past_grace_period,
+          queue_settings: queue_settings
         )
 
         expect(result).to eq(ms_to_seconds(retry_delay) * 2 ** (retries_past_grace_period - 1))
@@ -162,14 +131,7 @@ RSpec.describe EventQ::Amazon::CalculateVisibilityTimeout do
 
         result = subject.call(
           retry_attempts:       retry_back_off_grace + retries_past_grace_period,
-          queue_settings: {
-            allow_retry_back_off:       allow_retry_back_off,
-            allow_exponential_back_off: allow_exponential_back_off,
-            max_retry_delay:            max_retry_delay,
-            retry_back_off_grace:       retry_back_off_grace,
-            retry_delay:                retry_delay,
-            retry_back_off_weight:      retry_back_off_weight
-          }
+          queue_settings: queue_settings
         )
 
         expect(result).to eq(ms_to_seconds(max_retry_delay))


### PR DESCRIPTION
Our current implementation only has an algorithm that grows the back off linearly. For example if you have a 1 minute back off, the back off algorithm will grow the back off by 1 minute each time, i.e. 1 minute, 2 minutes, 3 minutes, etc. This is not ideal if you need your first retries within seconds, but want the last retry on the next day to allow for system recovery, and spread out retries nicely.

This commit adds an option to use an exponential back off algorithm. For example if you have a 1 minute back off, the back off algorithm will grow the back off by 1 minute, 2 minutes, 4 minutes, 8 minutes, 16 minutes, etc. This way you can start with seconds and end with days. We already have the option `queue_max_retry_delay` to cap how big the exponential function is allowed to grow.