### PR TITLE
Add option for jitter / randomness in retry delays

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ A subscription queue should be defined to receive any events raised for the subs
  - **require_signature** [Bool] [Optional] [Default=false] This is used to specify if messages within this queue must be signed.
  - **retry_delay** [Int] [Optional] [Default=30000] This is used to specify the time delay in milliseconds before a failed message is re-added to the subscription queue.
  - **retry_back_off_weight** [Int] [Optional] [Default=1] Additional multiplier for the timeout backoff. Normally used when `retry_delay` is too small (eg: 30ms) in order to get meaningful backoff values.
+ - **retry_jitter_ratio** [Int] [Optional] [Default=0] Amount of randomness for retry delays in percent to avoid a bulk of retries hitting again at the same time. 0% means no randomness, while 100% means full randomness. With full randomness, a random number between 0 and the calculated retry delay will be chosen for the delay.
 
 **Example**
 

--- a/lib/eventq/eventq_aws/aws_calculate_visibility_timeout.rb
+++ b/lib/eventq/eventq_aws/aws_calculate_visibility_timeout.rb
@@ -5,7 +5,7 @@ module EventQ
     # Class responsible to know how to calculate message Visibility Timeout for Amazon SQS
     class CalculateVisibilityTimeout
       def initialize(max_timeout:, logger: EventQ.logger)
-        @max_timeout = max_timeout
+        @max_timeout = seconds_to_ms(max_timeout)
         @logger      = logger
       end
 
@@ -30,14 +30,13 @@ module EventQ
         @retry_back_off_weight      = queue_settings.fetch(:retry_back_off_weight)
         @retry_delay                = queue_settings.fetch(:retry_delay)
 
-        if @allow_retry_back_off && retry_past_grace_period?
-          visibility_timeout = timeout_with_back_off
-          visibility_timeout = check_for_max_timeout(visibility_timeout)
+        visibility_timeout = if @allow_retry_back_off && retry_past_grace_period?
+          timeout_with_back_off
         else
-          visibility_timeout = timeout_without_back_off
+          timeout_without_back_off
         end
 
-        visibility_timeout
+        ms_to_seconds(visibility_timeout)
       end
 
       private
@@ -49,38 +48,50 @@ module EventQ
       end
 
       def timeout_without_back_off
-        ms_to_seconds(@retry_delay)
+        @retry_delay
       end
 
       def timeout_with_back_off
         factor = @retry_attempts - @retry_back_off_grace
+        weighted_retry_delay = @retry_delay * @retry_back_off_weight
 
         visibility_timeout = if @allow_exponential_back_off
-          ms_to_seconds(@retry_delay * @retry_back_off_weight * 2 ** (factor - 1))
+          weighted_retry_delay * 2 ** (factor - 1)
         else
-          ms_to_seconds(@retry_delay * @retry_back_off_weight * factor)
+          weighted_retry_delay * factor
         end
 
-        max_retry_delay = ms_to_seconds(@max_retry_delay)
-
-        if visibility_timeout > max_retry_delay
-          logger.debug { "[#{self.class}] - Max message back off retry delay reached: #{max_retry_delay}" }
-          visibility_timeout = max_retry_delay
-        end
-
-        visibility_timeout
+        visibility_timeout = check_for_max_retry_delay(visibility_timeout)
+        check_for_max_timeout(visibility_timeout)
       end
 
       def ms_to_seconds(value)
         value / 1000
       end
 
-      def check_for_max_timeout(visibility_timeout)
-        if visibility_timeout > @max_timeout
-          logger.debug { "[#{self.class}] - AWS max visibility timeout of 12 hours has been exceeded. Setting message retry delay to 12 hours." }
-          visibility_timeout = @max_timeout
+      def seconds_to_ms(value)
+        value * 1000
+      end
+
+      def check_for_max_retry_delay(visibility_timeout)
+        return visibility_timeout if visibility_timeout <= @max_retry_delay
+
+        logger.debug do
+          "[#{self.class}] - Max message back off retry delay reached: #{ms_to_seconds(@max_retry_delay)}"
         end
-        visibility_timeout
+
+        @max_retry_delay
+      end
+
+      def check_for_max_timeout(visibility_timeout)
+        return visibility_timeout if visibility_timeout <= @max_timeout
+
+        logger.debug do
+          "[#{self.class}] - AWS max visibility timeout of 12 hours has been exceeded. "\
+          "Setting message retry delay to 12 hours."
+        end
+
+        @max_timeout
       end
     end
   end

--- a/lib/eventq/eventq_aws/aws_queue_worker.rb
+++ b/lib/eventq/eventq_aws/aws_queue_worker.rb
@@ -119,24 +119,28 @@ module EventQ
 
           EventQ.logger.warn("[#{self.class}] - Message Id: #{args.id}. Rejected requesting retry. Attempts: #{retry_attempts}")
 
-          visibility_timeout = @calculate_visibility_timeout.call(
-            retry_attempts:       retry_attempts,
-            queue_settings: {
-              allow_retry_back_off:       queue.allow_retry_back_off,
-              allow_exponential_back_off: queue.allow_exponential_back_off,
-              max_retry_delay:            queue.max_retry_delay,
-              retry_back_off_grace:       queue.retry_back_off_grace,
-              retry_back_off_weight:      queue.retry_back_off_weight,
-              retry_jitter_ratio:         queue.retry_jitter_ratio,
-              retry_delay:                queue.retry_delay
-            }
-          )
+          visibility_timeout = calculate_visibility_timeout(retry_attempts, queue)
 
           EventQ.logger.debug { "[#{self.class}] - Sending message for retry. Message TTL: #{visibility_timeout}" }
           poller.change_message_visibility_timeout(msg, visibility_timeout)
 
           context.call_on_retry_block(message)
         end
+      end
+
+      def calculate_visibility_timeout(retry_attempts, queue)
+        @calculate_visibility_timeout.call(
+          retry_attempts: retry_attempts,
+          queue_settings: {
+            allow_retry_back_off:       queue.allow_retry_back_off,
+            allow_exponential_back_off: queue.allow_exponential_back_off,
+            max_retry_delay:            queue.max_retry_delay,
+            retry_back_off_grace:       queue.retry_back_off_grace,
+            retry_back_off_weight:      queue.retry_back_off_weight,
+            retry_jitter_ratio:         queue.retry_jitter_ratio,
+            retry_delay:                queue.retry_delay
+          }
+        )
       end
     end
   end

--- a/lib/eventq/eventq_aws/aws_queue_worker.rb
+++ b/lib/eventq/eventq_aws/aws_queue_worker.rb
@@ -127,6 +127,7 @@ module EventQ
               max_retry_delay:            queue.max_retry_delay,
               retry_back_off_grace:       queue.retry_back_off_grace,
               retry_back_off_weight:      queue.retry_back_off_weight,
+              retry_jitter_ratio:         queue.retry_jitter_ratio,
               retry_delay:                queue.retry_delay
             }
           )

--- a/lib/eventq/eventq_base/queue.rb
+++ b/lib/eventq/eventq_base/queue.rb
@@ -12,6 +12,7 @@ module EventQ
     attr_accessor :retry_delay
     attr_accessor :retry_back_off_grace
     attr_accessor :retry_back_off_weight
+    attr_accessor :retry_jitter_ratio
     # Character delimiter between namespace and queue name.  Default = '-'
     attr_accessor :namespace_delimiter
     # Flag to control that the queue runs in isolation of auto creating the topic it belongs to
@@ -37,6 +38,8 @@ module EventQ
       @retry_back_off_grace = 0
       # Multiplier for the backoff retry in case retry_delay is too small
       @retry_back_off_weight = 1
+      # Ratio of how much jitter to apply to the retry delay
+      @retry_jitter_ratio = 0
       @isolated = false
     end
   end

--- a/lib/eventq/eventq_rabbitmq/rabbitmq_queue_worker.rb
+++ b/lib/eventq/eventq_rabbitmq/rabbitmq_queue_worker.rb
@@ -134,7 +134,15 @@ module EventQ
           message_ttl = queue.max_retry_delay
         end
 
-        message_ttl
+        apply_jitter(queue.retry_jitter_ratio, message_ttl)
+      end
+
+      def apply_jitter(retry_jitter_ratio, message_ttl)
+        return message_ttl if retry_jitter_ratio == 0
+
+        ratio = retry_jitter_ratio / 100.0
+        min_message_ttl = (message_ttl * (1 - ratio)).to_i
+        rand(min_message_ttl..message_ttl)
       end
     end
   end

--- a/utilities/plot_visibility_timeout.rb
+++ b/utilities/plot_visibility_timeout.rb
@@ -16,6 +16,7 @@ class PlotVisibilityTimeout
     @queue_allow_retry_back_off       = settings.fetch(:queue_allow_retry_back_off)
     @queue_allow_exponential_back_off = settings.fetch(:queue_allow_exponential_back_off)
     @queue_retry_back_off_weight      = settings.fetch(:queue_retry_back_off_weight)
+    @queue_retry_jitter_ratio         = settings.fetch(:queue_retry_jitter_ratio)
     @queue_max_retry_delay            = settings.fetch(:queue_max_retry_delay)
     @queue_max_timeout                = settings.fetch(:queue_max_timeout)
     @queue_retry_back_off_grace       = settings.fetch(:queue_retry_back_off_grace)
@@ -76,7 +77,8 @@ class PlotVisibilityTimeout
         max_retry_delay:            @queue_max_retry_delay,
         retry_back_off_grace:       @queue_retry_back_off_grace,
         retry_back_off_weight:      @queue_retry_back_off_weight,
-        retry_delay:                @queue_retry_delay,
+        retry_jitter_ratio:         @queue_retry_jitter_ratio,
+        retry_delay:                @queue_retry_delay
       }
     )
   end
@@ -130,7 +132,10 @@ settings = {
   # Delay and retry for each queue iterations. The multiplier is necessary in case the calculated values
   # are insignificant between iterations.
   queue_retry_back_off_weight:      100,        # Backoff multiplier
-  queue_retry_delay:                30          # 30ms
+  queue_retry_delay:                30,         # 30ms
+
+  # Ratio of randomness allowed on retry delay to avoid a bulk of retries hitting again at the same time
+  queue_retry_jitter_ratio:         0           # ratio for randomness on retry delay
 }
 
 PlotVisibilityTimeout.new.plot(settings)


### PR DESCRIPTION
Jitter, or randomness in signals, is a common technique for avoiding calls that fail at the same time to retry at the same time. Therefore jitter can help avoid the thundering herd problem, where many instances of the same application all retry at the same time, causing a spike in load on the system. For example, if a service was down for some reason and comes back up, all queued events will hit at once and could cause the service to fail for most events. However, without jitter, the events will all retry at the same time, causing the same problem. Adding some jitter (or randomness) to the retry delays result in the events retrying at different times.

In our implementation, the configuration says how much jitter is used based on the retry delay. For example, if `retry_jitter_ratio` is set to 0, no jitter will be applied and all events will retry after the usual retry delay. If it is set to 100, the retry delay will be a random number between 0 and the retry delay without jitter. If it is set to 20, the retry delay will be a random number between 80 and 100% of the retry delay without jitter.