### PR TITLE
Fix oj usage in specs

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2']
+        ruby: ["2.7", "3.0", "3.2", "3.4"]
 
     services:
       eventq_redis:
@@ -62,13 +62,3 @@ jobs:
           AWS_SNS_ENDPOINT: http://localhost:4566
           RABBITMQ_ENDPOINT: localhost
           REDIS_ENDPOINT: redis://localhost:6379
-
-      - name: Code Coverage
-        uses: paambaati/codeclimate-action@v5
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
-        with:
-          prefix: '/src'
-          coverageLocations: |
-            ${{github.workspace}}/coverage/.resultset.json:simplecov
-

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'redis'
 
 platforms :ruby do
   gem 'bunny'
-  gem 'oj', '3.12.3' # 3.13.0 breaks the specs
+  gem 'oj', '3.16.11'
   gem 'openssl'
   gem 'rexml'
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '2.1'
-
 services:
   testrunner:
     build:

--- a/lib/eventq/eventq_base/serialization_providers/oj_serialization_provider.rb
+++ b/lib/eventq/eventq_base/serialization_providers/oj_serialization_provider.rb
@@ -11,12 +11,10 @@ module EventQ
       end
 
       def deserialize(json)
-        begin
-          Oj.load(json)
-        rescue Oj::ParseError, ArgumentError
-          EventQ.log(:debug, "[#{self.class}] - Failed to deserialize using Oj, falling back to JsonSerializationProvider.")
-          @json_serializer.deserialize(json)
-        end
+        Oj.load(json)
+      rescue Oj::ParseError, ArgumentError
+        EventQ.log(:debug, "[#{self.class}] - Failed to deserialize using Oj, falling back to JsonSerializationProvider.")
+        @json_serializer.deserialize(json)
       end
     end
   end

--- a/script/setup.sh
+++ b/script/setup.sh
@@ -1,5 +1,5 @@
 echo setup starting.....
-docker-compose rm
+docker compose rm
 
 echo build docker image
 docker build --no-cache -t eventq .

--- a/script/start.sh
+++ b/script/start.sh
@@ -1,4 +1,4 @@
 echo start containers
 
-docker-compose up -d
+docker compose up -d
 

--- a/script/stop.sh
+++ b/script/stop.sh
@@ -1,2 +1,2 @@
 echo stop containers
-docker-compose stop
+docker compose stop

--- a/script/test.sh
+++ b/script/test.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 echo start rspec tests
-docker-compose up -d
+docker compose up -d
 
 docker exec -it testrunner bash -c "bundle install && bundle exec rspec $*"

--- a/spec/eventq_aws/aws_queue_worker_spec.rb
+++ b/spec/eventq_aws/aws_queue_worker_spec.rb
@@ -79,7 +79,3 @@ RSpec.describe EventQ::Amazon::QueueWorker do
     end
   end
 end
-
-class A
-  attr_accessor :text
-end

--- a/spec/eventq_aws/aws_subscription_manager_spec.rb
+++ b/spec/eventq_aws/aws_subscription_manager_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe EventQ::Amazon::SubscriptionManager do
     context 'when Queue.isolated is true' do
       it 'raises an error if topic does not exist' do
         subscriber_queue.isolated = true
-        expect { subject.subscribe(event_type, subscriber_queue) }.to raise_error
+        expect { subject.subscribe(event_type, subscriber_queue) }.to raise_error(EventQ::Exceptions::EventTypeNotFound)
       end
     end
 

--- a/spec/eventq_rabbitmq/rabbitmq_queue_worker_spec.rb
+++ b/spec/eventq_rabbitmq/rabbitmq_queue_worker_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
         end
         let(:payload) do
           string = Oj.dump(a)
-          JSON.load(string.sub('"^o":"A"', '"^o":"B"'))
+          JSON.parse(string.sub('"^o":"A"', '"^o":"D"'))
         end
         let(:message) do
           EventQ::QueueMessage.new.tap do |m|
@@ -669,16 +669,10 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
       expect(failed_message.type).to eq(event_type)
 
       expect(queue_worker.running?).to eq(false)
-
     end
   end
 
-  class A
-    attr_accessor :text
-  end
-
   def add_to_received_list(received_messages)
-
     thread_name = Thread.current.object_id
     EventQ.logger.debug { "[THREAD] #{thread_name}" }
     thread = received_messages.select { |i| i[:thread] == thread_name }
@@ -688,6 +682,5 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
     else
       received_messages.push({ :events => 1, :thread => thread_name })
     end
-
   end
 end

--- a/spec/eventq_rabbitmq/rabbitmq_queue_worker_v2_spec.rb
+++ b/spec/eventq_rabbitmq/rabbitmq_queue_worker_v2_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
         end
         let(:payload) do
           string = Oj.dump(a)
-          JSON.load(string.sub('"^o":"A"', '"^o":"B"'))
+          JSON.parse(string.sub('"^o":"A"', '"^o":"C"'))
         end
         let(:message) do
           EventQ::QueueMessage.new.tap do |m|
@@ -649,16 +649,10 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
       expect(failed_message.type).to eq(event_type)
 
       expect(queue_worker.running?).to eq(false)
-
     end
   end
 
-  class A
-    attr_accessor :text
-  end
-
   def add_to_received_list(received_messages)
-
     thread_name = Thread.current.object_id
     EventQ.logger.debug { "[THREAD] #{thread_name}" }
     thread = received_messages.select { |i| i[:thread] == thread_name }
@@ -668,8 +662,5 @@ RSpec.describe EventQ::RabbitMq::QueueWorker do
     else
       received_messages.push({ :events => 1, :thread => thread_name })
     end
-
   end
-
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -57,3 +57,8 @@ RSpec.configure do |config|
 
   Kernel.srand config.seed
 end
+
+# Serdes test class
+class A
+  attr_accessor :text
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,6 +35,7 @@ RSpec.configure do |config|
 
   config.mock_with :rspec do |mocks|
     mocks.verify_partial_doubles = true
+    mocks.allow_message_expectations_on_nil = true
   end
 
   config.example_status_persistence_file_path = 'spec_run.txt'


### PR DESCRIPTION
Fixes https://github.com/Sage/eventq/issues/105

The issue was related to internal changes in the oj gem to the class cache and it not interacting well with our hacky way of testing their implementation.

This commit changes the specs to use different unknown class names per spec.


Also removes testing for Ruby < 2.7 and Codeclimate.