### PR TITLE
Make it easy to log Queue settings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:3.2-alpine3.18
 
-ENV APP_HOME /src
+ENV APP_HOME=/src
 RUN mkdir -p $APP_HOME
 WORKDIR $APP_HOME
 

--- a/lib/eventq/eventq_base/queue.rb
+++ b/lib/eventq/eventq_base/queue.rb
@@ -42,5 +42,26 @@ module EventQ
       @retry_jitter_ratio = 0
       @isolated = false
     end
+
+    def log_settings
+      EventQ.logger.info do
+        <<~LOG.chomp
+          [#{self.class}] - Settings: \
+          name='#{@name}', \
+          allow_retry='#{@allow_retry}', \
+          allow_retry_back_off='#{@allow_retry_back_off}', \
+          allow_exponential_back_off='#{@allow_exponential_back_off}', \
+          dlq='#{@dlq}', \
+          max_receive_count='#{@max_receive_count}', \
+          max_retry_attempts='#{@max_retry_attempts}', \
+          max_retry_delay='#{@max_retry_delay}', \
+          retry_delay='#{@retry_delay}', \
+          retry_back_off_grace='#{@retry_back_off_grace}', \
+          retry_back_off_weight='#{@retry_back_off_weight}', \
+          retry_jitter_ratio='#{@retry_jitter_ratio}', \
+          require_signature='#{@require_signature}'
+        LOG
+      end
+    end
   end
 end

--- a/spec/eventq_base/queue_spec.rb
+++ b/spec/eventq_base/queue_spec.rb
@@ -1,0 +1,50 @@
+require 'spec_helper'
+
+RSpec.describe EventQ::Queue do
+  let(:queue) { described_class.new }
+
+  describe '#log_settings' do
+    before do
+      @logged_message = nil
+      allow(EventQ.logger).to receive(:info) do |&block|
+        @logged_message = block.call
+      end
+    end
+
+    it 'logs the default settings' do
+      queue.log_settings
+
+      expect(@logged_message).to eq(
+        "[EventQ::Queue] - Settings: name='', allow_retry='false', allow_retry_back_off='false', " \
+        "allow_exponential_back_off='false', dlq='', max_receive_count='30', max_retry_attempts='5', " \
+        "max_retry_delay='5000', retry_delay='30000', retry_back_off_grace='0', retry_back_off_weight='1', " \
+        "retry_jitter_ratio='0', require_signature='false'"
+      )
+    end
+
+    it 'logs custom settings' do
+      queue.name = 'MyQueue'
+      queue.allow_retry = true
+      queue.allow_retry_back_off = true
+      queue.allow_exponential_back_off = true
+      queue.dlq = 'MyDLQ'
+      queue.max_receive_count = 50
+      queue.max_retry_attempts = 10
+      queue.max_retry_delay = 10000
+      queue.retry_delay = 60000
+      queue.retry_back_off_grace = 5
+      queue.retry_back_off_weight = 2
+      queue.retry_jitter_ratio = 100
+      queue.require_signature = true
+
+      queue.log_settings
+
+      expect(@logged_message).to eq(
+        "[EventQ::Queue] - Settings: name='MyQueue', allow_retry='true', allow_retry_back_off='true', " \
+        "allow_exponential_back_off='true', dlq='MyDLQ', max_receive_count='50', max_retry_attempts='10', " \
+        "max_retry_delay='10000', retry_delay='60000', retry_back_off_grace='5', retry_back_off_weight='2', " \
+        "retry_jitter_ratio='100', require_signature='true'"
+      )
+    end
+  end
+end


### PR DESCRIPTION
Because the Queue setup is done in the client and can be done in a variety of ways, we cannot automatically log the settings when the Queue is created. Instead, we provide a method to log the settings to call in the client when appropriate.

Logging the settings will help to make sure changes to your Queue configuration are applied and can also double check business logic around these settings are calculating the right outcome.