### PR TITLE
Remove the environment setting in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,6 @@ jobs:
       contents: write
       id-token: write
 
-    environment: release
-
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
The `environment` setting must match exactly what's set in RubyGems. However, it's optional so likely was not set (cannot check myself).