### PR TITLE
Lock localstack to community-archive tag

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -30,7 +30,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
       localstack:
-        image: localstack/localstack:latest
+        image: localstack/localstack:community-archive
         env:
           SQS_ENDPOINT_STRATEGY: off
           LOCALSTACK_HOST: localhost

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
 
   localstack:
     # changes to multi region support after this version break tests
-    image: localstack/localstack:stable
+    image: localstack/localstack:community-archive
     container_name: localstack
     environment:
       - SQS_ENDPOINT_STRATEGY=off


### PR DESCRIPTION
latest versions of localstack now need an auth_token